### PR TITLE
Small Change: Add info about dependency ruby2ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ group :metrics do
     gem 'metric_fu',   '~> 2.1.1'
     gem 'mspec',       '~> 1.5.17'
     gem 'rcov',        '~> 0.9.9'
-    gem 'ruby2ruby',   '= 1.2.2'
+    gem 'ruby2ruby',   '= 1.2.2'   # for heckle
   end
 
   platforms :rbx do


### PR DESCRIPTION
It is confusing, when something is in the Gemfile, but not required anywhere.
Therefore a comment should be added to those dependencies.

The dependency was discussed in moonglum/veritas@40dba8319cc07b53ce53a3de421e554421ccf2e6
