### PR TITLE
Add key support to relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ new_relation = relation.delete(other)
 
 # replace a relation variable with another set
 new_relation = relation.replace(other)
+
+# each subset of unique keys as header objects
+keys = header.keys
 ```
 
 ## Goals

--- a/TODO
+++ b/TODO
@@ -1,5 +1,7 @@
 * TODO:
 
+* Add key minimization
+
 * Make Equalizer handle subclasses without having to specify the attribtues
   again in each descendant.
 

--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 44
-total_score: 856
+total_score: 865

--- a/config/roodi.yml
+++ b/config/roodi.yml
@@ -2,7 +2,7 @@
 AbcMetricMethodCheck:            { score: 10.3 }
 AssignmentInConditionalCheck:    { }
 CaseMissingElseCheck:            { }
-ClassLineCountCheck:             { line_count: 294 }
+ClassLineCountCheck:             { line_count: 346 }
 ClassNameCheck:                  { pattern: !ruby/regexp '/\A(?:[A-Z]+|[A-Z][a-z](?:[A-Z]?[a-z])+)\z/' }
 ClassVariableCheck:              { }
 CyclomaticComplexityBlockCheck:  { complexity: 3 }
@@ -12,7 +12,7 @@ ForLoopCheck:                    { }
 # TODO: decrease line_count to 5 to 10
 MethodLineCountCheck:            { line_count: 14 }
 MethodNameCheck:                 { pattern: !ruby/regexp '/\A(?:[a-z\d](?:_?[a-z\d])+[?!=]?|\[\]=?|==|<=>|<<|[+*&|-])\z/' }
-ModuleLineCountCheck:            { line_count: 296 }
+ModuleLineCountCheck:            { line_count: 348 }
 ModuleNameCheck:                 { pattern: !ruby/regexp '/\A(?:[A-Z]+|[A-Z][a-z](?:[A-Z]?[a-z])+)\z/' }
 # TODO: decrease parameter_count to 2 or less
 ParameterNumberCheck:            { parameter_count: 3 }

--- a/config/site.reek
+++ b/config/site.reek
@@ -8,7 +8,7 @@ UncommunicativeParameterName:
   - !ruby/regexp /[0-9]$/
   - !ruby/regexp /[A-Z]/
 LargeClass:
-  max_methods: 14  # TODO: decrease max_methods to 10-15 or less
+  max_methods: 15  # TODO: decrease max_methods to 10-15 or less
   exclude: []
   enabled: true
   max_instance_variables: 4

--- a/lib/veritas.rb
+++ b/lib/veritas.rb
@@ -66,6 +66,7 @@ require 'veritas/relation'
 require 'veritas/relation/proxy'
 
 require 'veritas/relation/base'
+require 'veritas/relation/keys'
 require 'veritas/relation/header'
 
 require 'veritas/relation/materialized'

--- a/lib/veritas/relation/keys.rb
+++ b/lib/veritas/relation/keys.rb
@@ -31,7 +31,7 @@ module Veritas
         if object.kind_of?(self)
           object
         else
-          block ||= method(:coerce_attributes)
+          block ||= lambda { |attributes| coerce_attributes(attributes) }
           new(Array(object).map(&block))
         end
       end

--- a/lib/veritas/relation/keys.rb
+++ b/lib/veritas/relation/keys.rb
@@ -113,7 +113,11 @@ module Veritas
       #
       # @api public
       def extend(attributes)
-        new(map { |key| key | attributes })
+        if empty?
+          coerce(attributes)
+        else
+          new(map { |key| key | attributes })
+        end
       end
 
       # Return keys with the attributes renamed

--- a/lib/veritas/relation/keys.rb
+++ b/lib/veritas/relation/keys.rb
@@ -225,6 +225,9 @@ module Veritas
         self.class.coerce(object)
       end
 
+      # Represent an empty set of keys
+      EMPTY = new
+
     end # class Keys
   end # class Relation
 end # module Veritas

--- a/lib/veritas/relation/keys.rb
+++ b/lib/veritas/relation/keys.rb
@@ -1,0 +1,226 @@
+# encoding: utf-8
+
+module Veritas
+  class Relation
+
+    # A set of keys in a Header
+    class Keys
+      extend Aliasable
+      include Enumerable
+      include Equalizer.new(:to_set)
+
+      inheritable_alias(
+        :& => :intersect,
+        :| => :union,
+        :- => :difference
+      )
+
+      # Coerce an Array-like object into Keys
+      #
+      # @param [Keys, #to_ary] object
+      #
+      # @yield [attributes]
+      #
+      # @yieldparam [Header, Array] attributes
+      #   the attributes in each key
+      #
+      # @return [Keys]
+      #
+      # @api private
+      def self.coerce(object, &block)
+        if object.kind_of?(self)
+          object
+        else
+          block ||= method(:coerce_attributes)
+          new(Array(object).map(&block))
+        end
+      end
+
+      # Coerce the attributes into a Header
+      #
+      # @param [Object] attributes
+      #
+      # @return [Header]
+      #
+      # @api private
+      def self.coerce_attributes(attributes)
+        Header.coerce(attributes)
+      end
+
+      private_class_method :coerce_attributes
+
+      # Initialize Keys
+      #
+      # @example
+      #   keys = Keys.new([ [ :id ] ])
+      #
+      # @param [#to_ary] keys
+      #
+      # @return [undefined]
+      #
+      # @api public
+      def initialize(keys = [])
+        @keys = freeze_object(keys.to_ary)
+      end
+
+      # Iterate over each key in the Keys
+      #
+      # @example
+      #   keys = Keys.new(keys)
+      #   keys.each { |key| ... }
+      #
+      # @yield [key]
+      #
+      # @yieldparam [Header] key
+      #
+      # @return [self]
+      #
+      # @api public
+      def each
+        return to_enum unless block_given?
+        to_ary.each { |key| yield key }
+        self
+      end
+
+      # Return keys with only the attributes specified
+      #
+      # When the attributes do not match any attributes in an existing
+      # key, then the key should be removed because it means the attributes
+      # it applied against no longer exist in the new header.
+      #
+      # @example
+      #   projected = keys.project(attributes)
+      #
+      # @param [#map] attributes
+      #   the attributes to keep in the keys
+      #
+      # @return [Keys]
+      #
+      # @api public
+      def project(attributes)
+        new(map { |key| key & attributes }.delete_if(&:empty?))
+      end
+
+      # Return keys with the new attributes added
+      #
+      # @example
+      #   extended = keys.extend(attributes)
+      #
+      # @param [#to_ary] attributes
+      #   the attributes to add to the keys
+      #
+      # @return [Keys]
+      #
+      # @api public
+      def extend(attributes)
+        new(map { |key| key | attributes })
+      end
+
+      # Return keys with the attributes renamed
+      #
+      # @example
+      #   renamed = keys.rename(aliases)
+      #
+      # @param [Aliases] aliases
+      #   the old and new attribute names
+      #
+      # @return [Keys]
+      #
+      # @api public
+      def rename(aliases)
+        new(map { |key| key.rename(aliases) })
+      end
+
+      # Return the intersection of the keys with other keys
+      #
+      # @example
+      #   intersection = keys.intersect(other)
+      #
+      # @param [Keys] other
+      #
+      # @return [Keys]
+      #
+      # @api public
+      def intersect(other)
+        new(to_ary & other)
+      end
+
+      # Return the union of the keys with other keys
+      #
+      # @example
+      #   union = keys.union(other)
+      #
+      # @param [Keys] other
+      #
+      # @return [Keys]
+      #
+      # @api public
+      def union(other)
+        new(to_ary | other)
+      end
+
+      # Return the difference of the keys with other keys
+      #
+      # @example
+      #   difference = keys.difference(other)
+      #
+      # @param [Keys] other
+      #
+      # @return [Keys]
+      #
+      # @api public
+      def difference(other)
+        new(to_ary - other)
+      end
+
+      # Convert the Keys into an Array
+      #
+      # @example
+      #   array = keys.to_ary
+      #
+      # @return [Array]
+      #
+      # @api public
+      def to_ary
+        @keys
+      end
+
+      # Test if there are no keys
+      #
+      # @example
+      #   keys.empty?  # => true or false
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      def empty?
+        to_ary.empty?
+      end
+
+    private
+
+      # Utility method to instantiate Keys
+      #
+      # @param [Array] keys
+      #
+      # @return [Keys]
+      #
+      # @api private
+      def new(keys)
+        to_ary == keys ? self : self.class.new(keys)
+      end
+
+      # Coerce the object into Keys
+      #
+      # @param [Keys, #to_ary] object
+      #
+      # @return [Keys]
+      #
+      # @api private
+      def coerce(object)
+        self.class.coerce(object)
+      end
+
+    end # class Keys
+  end # class Relation
+end # module Veritas

--- a/spec/unit/veritas/relation/header/difference_spec.rb
+++ b/spec/unit/veritas/relation/header/difference_spec.rb
@@ -6,24 +6,30 @@ require 'spec_helper'
   describe Relation::Header, "##{method}" do
     subject { object.send(method, other) }
 
-    let(:object) { described_class.coerce([ [ :id, Integer ] ]) }
+    let(:object) { described_class.coerce([ [ :id, Integer ] ], :keys => keys) }
+    let(:other)  { described_class.coerce(other_attributes,     :keys => keys) }
+    let(:keys)   { Relation::Keys.new([ described_class.new ])                 }
 
     context 'when the attributes overlap' do
-      let(:other) { [ [ :id, Integer ] ] }
+      let(:other_attributes) { [ [ :id, Integer ] ] }
 
       it { should be_instance_of(described_class) }
 
       it { should be_empty }
+
+      its(:keys) { should equal(object.keys) }
     end
 
     context 'when the attributes do not overlap' do
-      let(:other) { [ [ :name, String ] ] }
+      let(:other_attributes) { [ [ :name, String ] ] }
 
       it { pending { should equal(object) } }
 
       it { should be_instance_of(described_class) }
 
       it { should == object }
+
+      its(:keys) { should eql(keys) }
     end
   end
 end

--- a/spec/unit/veritas/relation/header/extend_spec.rb
+++ b/spec/unit/veritas/relation/header/extend_spec.rb
@@ -5,26 +5,31 @@ require 'spec_helper'
 describe Relation::Header, '#extend' do
   subject { object.extend(attributes) }
 
-  let(:object) { described_class.coerce([ [ :id, Integer ], [ :name, String ] ]) }
+  let(:object) { described_class.coerce([ [ :id, Integer ] ], :keys => keys) }
+  let(:keys)   { Relation::Keys.new([ described_class.new ])                 }
 
   context 'with attribute objects' do
     let(:attributes) { [ attribute ]                }
-    let(:attribute)  { Attribute::Integer.new(:age) }
+    let(:attribute)  { Attribute::String.new(:name) }
 
     it { should be_instance_of(described_class) }
 
     it 'uses the attribute object' do
-      subject[:age].should equal(attribute)
+      subject[:name].should equal(attribute)
     end
 
-    its(:to_ary) { should == [ [ :id, Integer ], [ :name, String ], [ :age, Integer ] ] }
+    its(:to_ary) { should == [ [ :id, Integer ], [ :name, String ] ] }
+
+    its(:keys) { should equal(keys) }
   end
 
   context 'with Symbol attributes' do
-    let(:attributes) { [ :age ] }
+    let(:attributes) { [ :name ] }
 
     it { should be_instance_of(described_class) }
 
-    its(:to_ary) { should == [ [ :id, Integer ], [ :name, String ], [ :age, Object ] ] }
+    its(:to_ary) { should == [ [ :id, Integer ], [ :name, Object ] ] }
+
+    its(:keys) { should equal(keys) }
   end
 end

--- a/spec/unit/veritas/relation/header/hash_spec.rb
+++ b/spec/unit/veritas/relation/header/hash_spec.rb
@@ -5,10 +5,11 @@ require 'spec_helper'
 describe Relation::Header, '#hash' do
   subject { object.hash }
 
-  let(:object)    { described_class.new([ attribute ]) }
-  let(:attribute) { Attribute::Integer.new(:id)        }
+  let(:object)    { described_class.new([ attribute ], :keys => keys) }
+  let(:attribute) { Attribute::Integer.new(:id)                       }
+  let(:keys)      { Relation::Keys.new                                }
 
   it_should_behave_like 'a hash method'
 
-  it { should == described_class.hash ^ Set[attribute].hash }
+  it { should == described_class.hash ^ Set[attribute].hash ^ keys.hash }
 end

--- a/spec/unit/veritas/relation/header/intersect_spec.rb
+++ b/spec/unit/veritas/relation/header/intersect_spec.rb
@@ -6,24 +6,30 @@ require 'spec_helper'
   describe Relation::Header, "##{method}" do
     subject { object.send(method, other) }
 
-    let(:object) { described_class.coerce([ [ :id, Integer ] ]) }
+    let(:object) { described_class.coerce([ [ :id, Integer ] ], :keys => keys) }
+    let(:other)  { described_class.coerce(other_attributes,     :keys => keys) }
+    let(:keys)   { Relation::Keys.new([ described_class.new ])                 }
 
     context 'when the attributes overlap' do
-      let(:other) { [ [ :id, Integer ] ] }
+      let(:other_attributes) { [ [ :id, Integer ] ] }
 
       it { pending { should equal(object) } }
 
       it { should be_instance_of(described_class) }
 
-      its(:to_ary) { should == other }
+      its(:to_ary) { should == other_attributes }
+
+      its(:keys) { should eql(keys) }
     end
 
     context 'when the attributes do not overlap' do
-      let(:other) { [ [ :name, String ] ] }
+      let(:other_attributes) { [ [ :name, String ] ] }
 
       it { should be_instance_of(described_class) }
 
       it { should be_empty }
+
+      its(:keys) { should eql(keys) }
     end
   end
 end

--- a/spec/unit/veritas/relation/header/keys_spec.rb
+++ b/spec/unit/veritas/relation/header/keys_spec.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Relation::Header, '#keys' do
+  subject { object.keys }
+
+  let(:attributes) { [ [ :id, Integer ], [ :name, String ] ] }
+  let(:keys_class) { Relation::Keys                          }
+
+  context 'with explicit keys' do
+    let(:object) { described_class.coerce(attributes, :keys => keys) }
+    let(:keys)   { [ [ :id ] ]                                       }
+
+    it { should be_instance_of(keys_class) }
+
+    it 'has a set of keys' do
+      should == keys_class.new([ described_class.new([ object[:id] ]) ])
+    end
+
+    it { should be_frozen }
+  end
+
+  context 'with no explicit keys' do
+    let(:object) { described_class.coerce(attributes) }
+
+    it { should be_instance_of(keys_class) }
+
+    it 'has an empty set of keys' do
+      should be_empty
+    end
+
+    it { should be_frozen }
+  end
+end

--- a/spec/unit/veritas/relation/header/project_spec.rb
+++ b/spec/unit/veritas/relation/header/project_spec.rb
@@ -5,7 +5,8 @@ require 'spec_helper'
 describe Relation::Header, '#project' do
   subject { object.project(attributes) }
 
-  let(:object) { described_class.coerce([ [ :id, Integer ], [ :name, String ] ]) }
+  let(:object) { described_class.coerce([ [ :id, Integer ], [ :name, String ] ], :keys => keys)          }
+  let(:keys)   { Relation::Keys.new([ described_class.coerce([ [ :id, Integer ], [ :name, String ] ]) ]) }
 
   context 'with attribute objects' do
     let(:attributes) { [ attribute ]               }
@@ -26,5 +27,7 @@ describe Relation::Header, '#project' do
     it { should be_instance_of(described_class) }
 
     its(:to_ary) { should == [ [ :id, Integer ] ] }
+
+    its(:keys) { should eql(Relation::Keys.new([ described_class.coerce([ [ :id, Integer ] ]) ])) }
   end
 end

--- a/spec/unit/veritas/relation/header/rename_spec.rb
+++ b/spec/unit/veritas/relation/header/rename_spec.rb
@@ -5,12 +5,15 @@ require 'spec_helper'
 describe Relation::Header, '#rename' do
   subject { object.rename(aliases) }
 
-  let(:object)  { described_class.coerce([ [ :id, Integer ], [ :name, String ] ]) }
-  let(:aliases) { Algebra::Rename::Aliases.coerce(object, :id => :other_id)       }
+  let(:object)  { described_class.coerce([ [ :id, Integer ], [ :name, String ] ], :keys => keys) }
+  let(:aliases) { Algebra::Rename::Aliases.coerce(object, :id => :other_id)                      }
+  let(:keys)    { Relation::Keys.new([ described_class.coerce([ [ :id, Integer ] ]) ])           }
 
   it { should be_instance_of(described_class) }
 
   it { should_not equal(object) }
 
   its(:to_ary) { should == [ [ :other_id, Integer ], [ :name, String ] ] }
+
+  its(:keys) { should eql(Relation::Keys.new([ described_class.coerce([ [ :other_id, Integer ] ]) ])) }
 end

--- a/spec/unit/veritas/relation/header/union_spec.rb
+++ b/spec/unit/veritas/relation/header/union_spec.rb
@@ -6,24 +6,30 @@ require 'spec_helper'
   describe Relation::Header, "##{method}" do
     subject { object.send(method, other) }
 
-    let(:object) { described_class.coerce([ [ :id, Integer ] ]) }
+    let(:object) { described_class.coerce([ [ :id, Integer ] ], :keys => keys) }
+    let(:other)  { described_class.coerce(other_attributes,     :keys => keys) }
+    let(:keys)   { Relation::Keys.new([ described_class.new ])                 }
 
     context 'when the attributes overlap' do
-      let(:other) { [ [ :id, Integer ] ] }
+      let(:other_attributes) { [ [ :id, Integer ] ] }
 
       it { pending { should equal(object) } }
 
       it { should be_instance_of(described_class) }
 
-      its(:to_ary) { should == other }
+      its(:to_ary) { should == other_attributes }
+
+      its(:keys) { should eql(keys) }
     end
 
     context 'when the attributes do not overlap' do
-      let(:other) { [ [ :name, String ] ] }
+      let(:other_attributes) { [ [ :name, String ] ] }
 
       it { should be_instance_of(described_class) }
 
       its(:to_ary) { should == [ [ :id, Integer ], [ :name, String ] ] }
+
+      its(:keys) { should eql(keys) }
     end
   end
 end

--- a/spec/unit/veritas/relation/keys/class_methods/coerce_spec.rb
+++ b/spec/unit/veritas/relation/keys/class_methods/coerce_spec.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Relation::Keys, '.coerce' do
+  subject { object.coerce(argument) }
+
+  let(:object) { described_class }
+
+  context 'when the arguments are Keys' do
+    let(:argument) { object.new([ [ [ :id ] ] ]) }
+
+    it { should equal(argument) }
+  end
+
+  context 'when the argument responds to #to_ary' do
+    let(:argument) { [ [ [ :id ] ] ] }
+
+    it { should be_instance_of(object) }
+
+    it { should == argument }
+  end
+
+  context 'when the argument is not a Keys and does not respond to #to_ary' do
+    let(:argument) { Object.new }
+
+    specify { expect { subject }.to raise_error(NoMethodError) }
+  end
+end

--- a/spec/unit/veritas/relation/keys/difference_spec.rb
+++ b/spec/unit/veritas/relation/keys/difference_spec.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+[ :difference, :- ].each do |method|
+  describe Relation::Keys, "##{method}" do
+    subject { object.send(method, other) }
+
+    let(:object) { described_class.new([ header       ])         }
+    let(:other)  { described_class.new([ other_header ])         }
+    let(:header) { Relation::Header.coerce([ [ :id, Integer ] ]) }
+
+    context 'when the attributes overlap' do
+      let(:other_header) { Relation::Header.coerce([ [ :id, Integer ] ]) }
+
+      it { should be_instance_of(described_class) }
+
+      it { should be_empty }
+    end
+
+    context 'when the attributes do not overlap' do
+      let(:other_header) { Relation::Header.coerce([ [ :name, String ] ]) }
+
+      it { should equal(object) }
+    end
+  end
+end

--- a/spec/unit/veritas/relation/keys/difference_spec.rb
+++ b/spec/unit/veritas/relation/keys/difference_spec.rb
@@ -6,12 +6,12 @@ require 'spec_helper'
   describe Relation::Keys, "##{method}" do
     subject { object.send(method, other) }
 
-    let(:object) { described_class.new([ header       ])         }
-    let(:other)  { described_class.new([ other_header ])         }
-    let(:header) { Relation::Header.coerce([ [ :id, Integer ] ]) }
+    let(:object) { described_class.coerce([ header       ]) }
+    let(:other)  { described_class.coerce([ other_header ]) }
+    let(:header) { [ [ :id, Integer ] ]                     }
 
     context 'when the attributes overlap' do
-      let(:other_header) { Relation::Header.coerce([ [ :id, Integer ] ]) }
+      let(:other_header) { [ [ :id, Integer ] ] }
 
       it { should be_instance_of(described_class) }
 
@@ -19,7 +19,7 @@ require 'spec_helper'
     end
 
     context 'when the attributes do not overlap' do
-      let(:other_header) { Relation::Header.coerce([ [ :name, String ] ]) }
+      let(:other_header) { [ [ :name, String ] ] }
 
       it { should equal(object) }
     end

--- a/spec/unit/veritas/relation/keys/each_spec.rb
+++ b/spec/unit/veritas/relation/keys/each_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 describe Relation::Keys, '#each' do
   subject { object.each { |key| yields << key } }
 
-  let(:object) { described_class.new([ header ])      }
-  let(:header) { Relation::Header.coerce([ [ :id ] ]) }
-  let(:yields) { []                                   }
+  let(:object) { described_class.coerce([ header ]) }
+  let(:header) { [ [ :id ] ]                        }
+  let(:yields) { []                                 }
 
   it_should_behave_like 'an #each method'
 

--- a/spec/unit/veritas/relation/keys/each_spec.rb
+++ b/spec/unit/veritas/relation/keys/each_spec.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Relation::Keys, '#each' do
+  subject { object.each { |key| yields << key } }
+
+  let(:object) { described_class.new([ header ])      }
+  let(:header) { Relation::Header.coerce([ [ :id ] ]) }
+  let(:yields) { []                                   }
+
+  it_should_behave_like 'an #each method'
+
+  it 'yields each attribute' do
+    expect { subject }.to change { yields.dup }.
+      from([]).
+      to([ header ])
+  end
+end
+
+describe Relation::Keys do
+  subject { object.new }
+
+  let(:object) { described_class }
+
+  it { should be_kind_of(Enumerable) }
+
+  it 'case matches Enumerable' do
+    (Enumerable === subject).should be(true)
+  end
+end

--- a/spec/unit/veritas/relation/keys/empty_spec.rb
+++ b/spec/unit/veritas/relation/keys/empty_spec.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Relation::Keys, '#empty?' do
+  subject { object.empty? }
+
+  let(:object) { described_class.new(keys) }
+
+  context 'with keys' do
+    let(:keys) { [ Relation::Header.coerce([ [ :id ] ]) ] }
+
+    it { should be(false) }
+  end
+
+  context 'without keys' do
+    let(:keys) { [] }
+
+    it { should be(true) }
+  end
+end

--- a/spec/unit/veritas/relation/keys/empty_spec.rb
+++ b/spec/unit/veritas/relation/keys/empty_spec.rb
@@ -5,10 +5,10 @@ require 'spec_helper'
 describe Relation::Keys, '#empty?' do
   subject { object.empty? }
 
-  let(:object) { described_class.new(keys) }
+  let(:object) { described_class.coerce(keys) }
 
   context 'with keys' do
-    let(:keys) { [ Relation::Header.coerce([ [ :id ] ]) ] }
+    let(:keys) { [ [ [ :id ] ] ] }
 
     it { should be(false) }
   end

--- a/spec/unit/veritas/relation/keys/extend_spec.rb
+++ b/spec/unit/veritas/relation/keys/extend_spec.rb
@@ -5,9 +5,8 @@ require 'spec_helper'
 describe Relation::Keys, '#extend' do
   subject { object.extend(attributes) }
 
-  let(:object)    { described_class.new([ header ]) }
-  let(:header)    { Relation::Header.new            }
-  let(:attribute) { Attribute::Integer.new(:id)     }
+  let(:object)    { described_class.coerce([ header ]) }
+  let(:header)    { []                                 }
 
   context 'with attributes that do not change the keys' do
     let(:attributes) { [] }
@@ -16,10 +15,10 @@ describe Relation::Keys, '#extend' do
   end
 
   context 'with attributes that change the keys' do
-    let(:attributes) { [ attribute ] }
+    let(:attributes) { [ :id ] }
 
     it { should be_instance_of(described_class) }
 
-    it { should == described_class.new([ Relation::Header.coerce([ attribute ]) ]) }
+    it { should == [ attributes ] }
   end
 end

--- a/spec/unit/veritas/relation/keys/extend_spec.rb
+++ b/spec/unit/veritas/relation/keys/extend_spec.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Relation::Keys, '#extend' do
+  subject { object.extend(attributes) }
+
+  let(:object)    { described_class.new([ header ]) }
+  let(:header)    { Relation::Header.new            }
+  let(:attribute) { Attribute::Integer.new(:id)     }
+
+  context 'with attributes that do not change the keys' do
+    let(:attributes) { [] }
+
+    it { should equal(object) }
+  end
+
+  context 'with attributes that change the keys' do
+    let(:attributes) { [ attribute ] }
+
+    it { should be_instance_of(described_class) }
+
+    it { should == described_class.new([ Relation::Header.coerce([ attribute ]) ]) }
+  end
+end

--- a/spec/unit/veritas/relation/keys/extend_spec.rb
+++ b/spec/unit/veritas/relation/keys/extend_spec.rb
@@ -21,4 +21,13 @@ describe Relation::Keys, '#extend' do
 
     it { should == [ attributes ] }
   end
+
+  context 'when the keys are empty' do
+    let(:object)     { described_class.new }
+    let(:attributes) { [ :id ]             }
+
+    it { should be_instance_of(described_class) }
+
+    it { should == [ attributes ] }
+  end
 end

--- a/spec/unit/veritas/relation/keys/intersect_spec.rb
+++ b/spec/unit/veritas/relation/keys/intersect_spec.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+[ :intersect, :& ].each do |method|
+  describe Relation::Keys, "##{method}" do
+    subject { object.send(method, other) }
+
+    let(:object) { described_class.new([ header       ])         }
+    let(:other)  { described_class.new([ other_header ])         }
+    let(:header) { Relation::Header.coerce([ [ :id, Integer ] ]) }
+
+    context 'when the attributes overlap' do
+      let(:other_header) { Relation::Header.coerce([ [ :id, Integer ] ]) }
+
+      it { should equal(object) }
+    end
+
+    context 'when the attributes do not overlap' do
+      let(:other_header) { Relation::Header.coerce([ [ :name, String ] ]) }
+
+      it { should be_instance_of(described_class) }
+
+      it { should be_empty }
+    end
+  end
+end

--- a/spec/unit/veritas/relation/keys/intersect_spec.rb
+++ b/spec/unit/veritas/relation/keys/intersect_spec.rb
@@ -6,18 +6,18 @@ require 'spec_helper'
   describe Relation::Keys, "##{method}" do
     subject { object.send(method, other) }
 
-    let(:object) { described_class.new([ header       ])         }
-    let(:other)  { described_class.new([ other_header ])         }
-    let(:header) { Relation::Header.coerce([ [ :id, Integer ] ]) }
+    let(:object) { described_class.coerce([ header       ]) }
+    let(:other)  { described_class.coerce([ other_header ]) }
+    let(:header) { [ [ :id ] ]                              }
 
     context 'when the attributes overlap' do
-      let(:other_header) { Relation::Header.coerce([ [ :id, Integer ] ]) }
+      let(:other_header) { header.dup }
 
       it { should equal(object) }
     end
 
     context 'when the attributes do not overlap' do
-      let(:other_header) { Relation::Header.coerce([ [ :name, String ] ]) }
+      let(:other_header) { [ [ :name ] ] }
 
       it { should be_instance_of(described_class) }
 

--- a/spec/unit/veritas/relation/keys/project_spec.rb
+++ b/spec/unit/veritas/relation/keys/project_spec.rb
@@ -5,23 +5,23 @@ require 'spec_helper'
 describe Relation::Keys, '#project' do
   subject { object.project(attributes) }
 
-  let(:object)         { described_class.new([ header ])                        }
-  let(:header)         { Relation::Header.new([ id_attribute, name_attribute ]) }
-  let(:id_attribute)   { Attribute::Integer.new(:id)                            }
-  let(:name_attribute) { Attribute::String.new(:name)                           }
+  let(:object) { described_class.coerce([ header ]) }
+  let(:header) { [ id, name ]                       }
+  let(:id)     { [ :id   ]                          }
+  let(:name)   { [ :name ]                          }
 
   context 'with attributes that do not change the keys' do
-    let(:attributes) { [ id_attribute, name_attribute ] }
+    let(:attributes) { [ id, name ] }
 
     it { should equal(object) }
   end
 
   context 'with attributes that change the keys' do
-    let(:attributes) { [ id_attribute ] }
+    let(:attributes) { [ id ] }
 
     it { should be_instance_of(described_class) }
 
-    it { should == described_class.new([ Relation::Header.coerce([ id_attribute ]) ]) }
+    it { should == [ [ id ] ] }
   end
 
   context 'with attributes that clear the keys' do
@@ -29,6 +29,6 @@ describe Relation::Keys, '#project' do
 
     it { should be_instance_of(described_class) }
 
-    it { should == described_class.new }
+    it { should be_empty }
   end
 end

--- a/spec/unit/veritas/relation/keys/project_spec.rb
+++ b/spec/unit/veritas/relation/keys/project_spec.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Relation::Keys, '#project' do
+  subject { object.project(attributes) }
+
+  let(:object)         { described_class.new([ header ])                        }
+  let(:header)         { Relation::Header.new([ id_attribute, name_attribute ]) }
+  let(:id_attribute)   { Attribute::Integer.new(:id)                            }
+  let(:name_attribute) { Attribute::String.new(:name)                           }
+
+  context 'with attributes that do not change the keys' do
+    let(:attributes) { [ id_attribute, name_attribute ] }
+
+    it { should equal(object) }
+  end
+
+  context 'with attributes that change the keys' do
+    let(:attributes) { [ id_attribute ] }
+
+    it { should be_instance_of(described_class) }
+
+    it { should == described_class.new([ Relation::Header.coerce([ id_attribute ]) ]) }
+  end
+
+  context 'with attributes that clear the keys' do
+    let(:attributes) { [] }
+
+    it { should be_instance_of(described_class) }
+
+    it { should == described_class.new }
+  end
+end

--- a/spec/unit/veritas/relation/keys/rename_spec.rb
+++ b/spec/unit/veritas/relation/keys/rename_spec.rb
@@ -5,12 +5,12 @@ require 'spec_helper'
 describe Relation::Keys, '#rename' do
   subject { object.rename(aliases) }
 
-  let(:object)  { described_class.new([ header1, header2 ])                  }
-  let(:header1) { Relation::Header.coerce([ [ :id, Integer ] ])              }
-  let(:header2) { Relation::Header.coerce([ [ :name, String ] ])             }
+  let(:object)  { described_class.coerce([ header1, header2 ])               }
+  let(:header1) { [ [ :id, Integer ] ]                                       }
+  let(:header2) { [ [ :name, String ] ]                                      }
   let(:aliases) { Algebra::Rename::Aliases.coerce(header1, :id => :other_id) }
 
   it { should be_instance_of(described_class) }
 
-  it { should == described_class.new([ Relation::Header.coerce([ [ :other_id, Integer ] ]), header2 ]) }
+  it { should == [ [ [ :other_id, Integer ] ], header2 ] }
 end

--- a/spec/unit/veritas/relation/keys/rename_spec.rb
+++ b/spec/unit/veritas/relation/keys/rename_spec.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Relation::Keys, '#rename' do
+  subject { object.rename(aliases) }
+
+  let(:object)  { described_class.new([ header1, header2 ])                  }
+  let(:header1) { Relation::Header.coerce([ [ :id, Integer ] ])              }
+  let(:header2) { Relation::Header.coerce([ [ :name, String ] ])             }
+  let(:aliases) { Algebra::Rename::Aliases.coerce(header1, :id => :other_id) }
+
+  it { should be_instance_of(described_class) }
+
+  it { should == described_class.new([ Relation::Header.coerce([ [ :other_id, Integer ] ]), header2 ]) }
+end

--- a/spec/unit/veritas/relation/keys/to_ary_spec.rb
+++ b/spec/unit/veritas/relation/keys/to_ary_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe Relation::Keys, '#to_ary' do
   subject { object.to_ary }
 
-  let(:object) { described_class.new([ header ])      }
-  let(:header) { Relation::Header.coerce([ [ :id ] ]) }
+  let(:object) { described_class.coerce([ header ]) }
+  let(:header) { [ [ :id ] ]                        }
 
   it { should be_instance_of(Array) }
 

--- a/spec/unit/veritas/relation/keys/to_ary_spec.rb
+++ b/spec/unit/veritas/relation/keys/to_ary_spec.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Relation::Keys, '#to_ary' do
+  subject { object.to_ary }
+
+  let(:object) { described_class.new([ header ])      }
+  let(:header) { Relation::Header.coerce([ [ :id ] ]) }
+
+  it { should be_instance_of(Array) }
+
+  it { should == [ header ] }
+
+  it { should be_frozen }
+end

--- a/spec/unit/veritas/relation/keys/union_spec.rb
+++ b/spec/unit/veritas/relation/keys/union_spec.rb
@@ -6,22 +6,22 @@ require 'spec_helper'
   describe Relation::Keys, "##{method}" do
     subject { object.send(method, other) }
 
-    let(:object) { described_class.new([ header       ])        }
-    let(:other)  { described_class.new([ other_header ])        }
-    let(:header) { Relation::Header.coerce([ [ :id, Integer] ]) }
+    let(:object) { described_class.coerce([ header       ]) }
+    let(:other)  { described_class.coerce([ other_header ]) }
+    let(:header) { [ [ :id, Integer] ]                      }
 
     context 'when the attributes overlap' do
-      let(:other_header) { Relation::Header.coerce([ [ :id, Integer ] ]) }
+      let(:other_header) { [ [ :id, Integer ] ] }
 
       it { should equal(object) }
     end
 
     context 'when the attributes do not overlap' do
-      let(:other_header) { Relation::Header.coerce([ [ :name, String ] ]) }
+      let(:other_header) { [ [ :name, String ] ] }
 
       it { should be_instance_of(described_class) }
 
-      it { should == described_class.new([ header, other_header ]) }
+      it { should == [ header, other_header ] }
     end
   end
 end

--- a/spec/unit/veritas/relation/keys/union_spec.rb
+++ b/spec/unit/veritas/relation/keys/union_spec.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+[ :union, :| ].each do |method|
+  describe Relation::Keys, "##{method}" do
+    subject { object.send(method, other) }
+
+    let(:object) { described_class.new([ header       ])        }
+    let(:other)  { described_class.new([ other_header ])        }
+    let(:header) { Relation::Header.coerce([ [ :id, Integer] ]) }
+
+    context 'when the attributes overlap' do
+      let(:other_header) { Relation::Header.coerce([ [ :id, Integer ] ]) }
+
+      it { should equal(object) }
+    end
+
+    context 'when the attributes do not overlap' do
+      let(:other_header) { Relation::Header.coerce([ [ :name, String ] ]) }
+
+      it { should be_instance_of(described_class) }
+
+      it { should == described_class.new([ header, other_header ]) }
+    end
+  end
+end

--- a/tasks/metrics/heckle.rake
+++ b/tasks/metrics/heckle.rake
@@ -45,6 +45,7 @@ begin
 
       %w[
         Veritas::Relation::Header
+        Veritas::Relation::Keys
         Veritas::Algebra::Difference::Methods
         Veritas::Algebra::Intersection::Methods
         Veritas::Algebra::Join::Methods

--- a/veritas.gemspec
+++ b/veritas.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Dan Kubb"]
-  s.date = "2012-12-24"
+  s.date = "2012-12-27"
   s.description = "Simplifies querying of structured data using relational algebra"
   s.email = "dan.kubb@gmail.com"
   s.extra_rdoc_files = [
@@ -682,7 +682,7 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<adamantium>, ["~> 0.0.4"])
       s.add_runtime_dependency(%q<backports>, ["~> 2.6.4"])
       s.add_runtime_dependency(%q<descendants_tracker>, ["~> 0.0.1"])
-      s.add_runtime_dependency(%q<equalizer>, ["~> 0.0.1"])
+      s.add_runtime_dependency(%q<equalizer>, ["~> 0.0.2"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.3"])
       s.add_development_dependency(%q<rake>, ["~> 10.0.3"])
       s.add_development_dependency(%q<rspec>, ["~> 1.3.2"])
@@ -692,7 +692,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<adamantium>, ["~> 0.0.4"])
       s.add_dependency(%q<backports>, ["~> 2.6.4"])
       s.add_dependency(%q<descendants_tracker>, ["~> 0.0.1"])
-      s.add_dependency(%q<equalizer>, ["~> 0.0.1"])
+      s.add_dependency(%q<equalizer>, ["~> 0.0.2"])
       s.add_dependency(%q<jeweler>, ["~> 1.8.3"])
       s.add_dependency(%q<rake>, ["~> 10.0.3"])
       s.add_dependency(%q<rspec>, ["~> 1.3.2"])
@@ -703,7 +703,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<adamantium>, ["~> 0.0.4"])
     s.add_dependency(%q<backports>, ["~> 2.6.4"])
     s.add_dependency(%q<descendants_tracker>, ["~> 0.0.1"])
-    s.add_dependency(%q<equalizer>, ["~> 0.0.1"])
+    s.add_dependency(%q<equalizer>, ["~> 0.0.2"])
     s.add_dependency(%q<jeweler>, ["~> 1.8.3"])
     s.add_dependency(%q<rake>, ["~> 10.0.3"])
     s.add_dependency(%q<rspec>, ["~> 1.3.2"])

--- a/veritas.gemspec
+++ b/veritas.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Dan Kubb"]
-  s.date = "2012-12-20"
+  s.date = "2012-12-24"
   s.description = "Simplifies querying of structured data using relational algebra"
   s.email = "dan.kubb@gmail.com"
   s.extra_rdoc_files = [
@@ -114,6 +114,7 @@ Gem::Specification.new do |s|
     "lib/veritas/relation/base.rb",
     "lib/veritas/relation/empty.rb",
     "lib/veritas/relation/header.rb",
+    "lib/veritas/relation/keys.rb",
     "lib/veritas/relation/materialized.rb",
     "lib/veritas/relation/operation/binary.rb",
     "lib/veritas/relation/operation/combination.rb",
@@ -541,11 +542,22 @@ Gem::Specification.new do |s|
     "spec/unit/veritas/relation/header/extend_spec.rb",
     "spec/unit/veritas/relation/header/hash_spec.rb",
     "spec/unit/veritas/relation/header/intersect_spec.rb",
+    "spec/unit/veritas/relation/header/keys_spec.rb",
     "spec/unit/veritas/relation/header/project_spec.rb",
     "spec/unit/veritas/relation/header/rename_spec.rb",
     "spec/unit/veritas/relation/header/to_ary_spec.rb",
     "spec/unit/veritas/relation/header/union_spec.rb",
     "spec/unit/veritas/relation/header_spec.rb",
+    "spec/unit/veritas/relation/keys/class_methods/coerce_spec.rb",
+    "spec/unit/veritas/relation/keys/difference_spec.rb",
+    "spec/unit/veritas/relation/keys/each_spec.rb",
+    "spec/unit/veritas/relation/keys/empty_spec.rb",
+    "spec/unit/veritas/relation/keys/extend_spec.rb",
+    "spec/unit/veritas/relation/keys/intersect_spec.rb",
+    "spec/unit/veritas/relation/keys/project_spec.rb",
+    "spec/unit/veritas/relation/keys/rename_spec.rb",
+    "spec/unit/veritas/relation/keys/to_ary_spec.rb",
+    "spec/unit/veritas/relation/keys/union_spec.rb",
     "spec/unit/veritas/relation/materialize_spec.rb",
     "spec/unit/veritas/relation/materialized/class_methods/new_spec.rb",
     "spec/unit/veritas/relation/materialized/directions_spec.rb",


### PR DESCRIPTION
This branch adds key support to relations. It introduces a new object called Relation::Keys, which is basically a set of Relation::Header objects, each of them representing a candidate key. A Relation::Header#keys attribute stores a reference to the keys for the relation.
