### PR TITLE
Assert irreducible keys

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 44
-total_score: 876
+total_score: 882

--- a/lib/veritas.rb
+++ b/lib/veritas.rb
@@ -159,7 +159,7 @@ module Veritas
   class RelationMismatchError < StandardError; end
 
   # Raised when a name is a duplicate of another name in a set
-  class DuplicateNameError < StandardError; end
+  class DuplicateNameError < ArgumentError; end
 
   # Raised when the attribute is unknown
   class UnknownAttributeError < IndexError; end

--- a/lib/veritas.rb
+++ b/lib/veritas.rb
@@ -164,6 +164,9 @@ module Veritas
   # Raised when the attribute is unknown
   class UnknownAttributeError < IndexError; end
 
+  # Raised when the key is reducible
+  class ReducibleKeyError < ArgumentError; end
+
   # Raised when a relation insertion or deletion fails
   class WriteError < StandardError; end
 

--- a/lib/veritas/algebra/projection.rb
+++ b/lib/veritas/algebra/projection.rb
@@ -102,7 +102,7 @@ module Veritas
       def assert_removed_attributes_optional
         names = required_attribute_names
         if names.any?
-          raise RequiredAttributesError, "required attributes #{names.join(', ')} have been removed"
+          raise RequiredAttributesError, "required attributes #{names.inspect} have been removed"
         end
       end
 

--- a/lib/veritas/relation/header.rb
+++ b/lib/veritas/relation/header.rb
@@ -90,7 +90,7 @@ module Veritas
       def self.assert_unique_names(names)
         duplicates = duplicate_names(names)
         if duplicates
-          raise DuplicateNameError, "duplicate names: #{duplicates.join(', ')}"
+          raise DuplicateNameError, "duplicate names: #{duplicates.inspect}"
         end
       end
 

--- a/lib/veritas/relation/keys.rb
+++ b/lib/veritas/relation/keys.rb
@@ -36,6 +36,21 @@ module Veritas
         end
       end
 
+      # Instantiate Keys
+      #
+      # @example
+      #   keys = Keys.new(keys)
+      #
+      # @param [Array<Header>] keys
+      #
+      # @return [Keys]
+      #
+      # @api public
+      def self.new(keys = [])
+        assert_irreducible_keys(keys.map { |key| key.to_set })
+        super
+      end
+
       # Coerce the attributes into a Header
       #
       # @param [Object] attributes
@@ -47,20 +62,49 @@ module Veritas
         Header.coerce(attributes)
       end
 
-      private_class_method :coerce_attributes
+      # Assert the keys are irreducible
+      #
+      # @param [Array<Set>] keys
+      #
+      # @return [undefined]
+      #
+      # @raise [ReducibleKeyError]
+      #   raised if a key can be reduced
+      #
+      # @api private
+      def self.assert_irreducible_keys(keys)
+        reducible_keys = reducible_keys(keys)
+        if reducible_keys
+          raise ReducibleKeyError, "reducible keys: #{reducible_keys.inspect}"
+        end
+      end
+
+      # The keys that can be reduced
+      #
+      # @param [Array<Header>] keys
+      #
+      # @return [Boolean]
+      #
+      # @api private
+      def self.reducible_keys(keys)
+        keys.permutation(2).select { |key, other| key.proper_superset?(other) }.
+          transpose.first
+      end
+
+      private_class_method :coerce_attributes, :assert_irreducible_keys, :reducible_keys
 
       # Initialize Keys
       #
       # @example
       #   keys = Keys.new([ [ :id ] ])
       #
-      # @param [#to_ary] keys
+      # @param [Array<Header>] keys
       #
       # @return [undefined]
       #
       # @api public
-      def initialize(keys = [])
-        @keys = freeze_object(keys.to_ary)
+      def initialize(keys)
+        @keys = freeze_object(keys)
       end
 
       # Iterate over each key in the Keys

--- a/lib/veritas/relation/keys.rb
+++ b/lib/veritas/relation/keys.rb
@@ -64,6 +64,11 @@ module Veritas
 
       # Assert the keys are irreducible
       #
+      # In a relation a candidate key must be irreducible, which means that
+      # there can't exist another key that is a proper subset of it. If this
+      # occurs, we should raise an exception because it means there is a
+      # specification error in the system.
+      #
       # @param [Array<Set>] keys
       #
       # @return [undefined]

--- a/spec/unit/veritas/algebra/extension/class_methods/new_spec.rb
+++ b/spec/unit/veritas/algebra/extension/class_methods/new_spec.rb
@@ -17,6 +17,6 @@ describe Algebra::Extension, '.new' do
   context 'with a duplicate attribute name provided' do
     let(:extensions) { { :id => proc {}, :name => proc {} } }
 
-    specify { expect { subject }.to raise_error(DuplicateNameError, 'duplicate names: id, name') }
+    specify { expect { subject }.to raise_error(DuplicateNameError, 'duplicate names: [:id, :name]') }
   end
 end

--- a/spec/unit/veritas/algebra/projection/insert_spec.rb
+++ b/spec/unit/veritas/algebra/projection/insert_spec.rb
@@ -53,7 +53,7 @@ describe Algebra::Projection, '#insert' do
     let(:other)       { Relation.new(header,      LazyEnumerable.new([ [ 2 ]                 ])) }
     let(:base_header) { [ [ :id, Integer ], [ :name, String ], [ :age, Integer ] ]               }
 
-    specify { expect { subject }.to raise_error(RequiredAttributesError, 'required attributes name, age have been removed') }
+    specify { expect { subject }.to raise_error(RequiredAttributesError, 'required attributes [:name, :age] have been removed') }
   end
 
   context 'when the other header does not match the projection' do

--- a/spec/unit/veritas/relation/header/class_methods/new_spec.rb
+++ b/spec/unit/veritas/relation/header/class_methods/new_spec.rb
@@ -29,7 +29,7 @@ describe Relation::Header, '.new' do
   context 'with an argument that responds to #to_ary and contain duplicates' do
     let(:argument) { [ id, id, name, name, name, age ] }
 
-    specify { expect { subject }.to raise_error(DuplicateNameError, 'duplicate names: id, name') }
+    specify { expect { subject }.to raise_error(DuplicateNameError, 'duplicate names: [:id, :name]') }
   end
 
   context 'with an argument that does not respond to #to_ary' do

--- a/spec/unit/veritas/relation/keys/class_methods/coerce_spec.rb
+++ b/spec/unit/veritas/relation/keys/class_methods/coerce_spec.rb
@@ -18,7 +18,7 @@ describe Relation::Keys, '.coerce' do
 
     it { should be_instance_of(object) }
 
-    it { should == argument }
+    it { should == [ Relation::Header.coerce([ :id ]) ] }
   end
 
   context 'when the argument is not a Keys and does not respond to #to_ary' do

--- a/spec/unit/veritas/relation/keys/class_methods/new_spec.rb
+++ b/spec/unit/veritas/relation/keys/class_methods/new_spec.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Relation::Keys, '.new' do
+  subject { object.new(argument) }
+
+  let(:object) { described_class              }
+  let(:id)     { Attribute::Integer.new(:id)  }
+  let(:name)   { Attribute::String.new(:name) }
+
+  context 'with no arguments' do
+    subject { object.new }
+
+    it { should be_instance_of(object) }
+
+    it { should be_empty }
+  end
+
+  context 'with an argument that responds to #to_ary and contains irreducible keys' do
+    let(:argument) { [ Relation::Header.new([ id ]) ] }
+
+    it { should be_instance_of(object) }
+
+    it { should == argument }
+  end
+
+  context 'with an argument that responds to #to_ary and contains reducible keys' do
+    let(:argument)        { [ reducible_key, irreducible_key ] }
+    let(:reducible_key)   { Relation::Header.new([ id, name ]) }
+    let(:irreducible_key) { Relation::Header.new([ id ])       }
+
+    specify { expect { subject }.to raise_error(ReducibleKeyError, "reducible keys: #{[ reducible_key.to_set ].inspect}") }
+  end
+
+  context 'when the argument is not a Keys and does not respond to #to_ary' do
+    let(:argument) { Object.new }
+
+    specify { expect { subject }.to raise_error(NoMethodError) }
+  end
+end

--- a/spec/unit/veritas/relation/operation/order/direction_set/class_methods/new_spec.rb
+++ b/spec/unit/veritas/relation/operation/order/direction_set/class_methods/new_spec.rb
@@ -21,6 +21,6 @@ describe Relation::Operation::Order::DirectionSet, '.new' do
   context 'with an argument that responds to #to_ary and contain duplicates' do
     let(:argument) { [ id, id, name, name, age ] }
 
-    specify { expect { subject }.to raise_error(DuplicateNameError, 'duplicate names: id, name') }
+    specify { expect { subject }.to raise_error(DuplicateNameError, 'duplicate names: [:id, :name]') }
   end
 end


### PR DESCRIPTION
This branch adds an assertion to Keys.new that will raise an exception if the keys are not irreducible, that is they can be further decomposed into a key containing a subset of the attributes.
