### PR TITLE
Adamantium zero arity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
+gem 'adamantium', :git => 'https://github.com/dkubb/adamantium.git'
+
 gemspec
 
 group :development do
@@ -33,7 +35,8 @@ end
 group :metrics do
   gem 'flay',      '~> 1.4.3'
   gem 'flog',      '~> 2.5.3'
-  gem 'reek',      '~> 1.2.8', :github => 'dkubb/reek'
+  # Current reek has incompatible ruby2ruby version requirement and dkubb/reek has gone :(
+  gem 'reek',      '~> 1.2.8' #, :git => 'https://github.com/troessner/reek.git'
   gem 'roodi',     '~> 2.1.0'
   gem 'yardstick', '~> 0.8.0'
 

--- a/lib/veritas/relation.rb
+++ b/lib/veritas/relation.rb
@@ -217,6 +217,17 @@ module Veritas
       none?
     end
 
+    # Return set of tuples
+    #
+    # @return [Set<Tuple>]
+    #
+    # @api private
+    #
+    def to_set
+      super()
+    end
+    memoize :to_set
+
   private
 
     # Coerce an Enumerable into a Relation
@@ -263,8 +274,6 @@ module Veritas
           "one tuple expected, but set contained #{size} tuples"
       end
     end
-
-    memoize :to_set
 
   end # class Relation
 end # module Veritas


### PR DESCRIPTION
This PR fixes a case where veritas is memoizing a method that has a nonzero arity.

It includes two commits where only one should end up in master.
- 4cd0456 fixes the problem
- d08e29c Uses adamantium from current master, with the zero arity assertion. To make reproduction easy. And can be savely ignored as adamantium with the assertion will be released soon (?)

As there is no git source for reek that contains the Irresponsible module fix and is compatible to heckle ci is subjected to fail. The reek issue needs to be addressed as currently reek ^ heckle .
