### PR TITLE
Bump backports to 2.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :metrics do
   gem 'flay',      '~> 1.4.3'
   gem 'flog',      '~> 2.5.3'
   gem 'roodi',     '~> 2.1.0'
-  gem 'yardstick', '~> 0.8.0'
+  gem 'yardstick', '~> 0.9.0'
 
   platforms :ruby_18, :ruby_19 do
     # this indirectly depends on ffi which does not build on ruby-head

--- a/veritas.gemspec
+++ b/veritas.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('abstract_type',       '~> 0.0.2')
   gem.add_runtime_dependency('adamantium',          '~> 0.0.4')
-  gem.add_runtime_dependency('backports',           '~> 2.6.4')
+  gem.add_runtime_dependency('backports',           '~> 2.7.0')
   gem.add_runtime_dependency('descendants_tracker', '~> 0.0.1')
   gem.add_runtime_dependency('equalizer',           '~> 0.0.2')
 end


### PR DESCRIPTION
Lets see what travis is saying. Devtools is well prepared, but might need to be updated also, in this case I'll add a commit to this PR.
