### PR TITLE
Bump version to 0.0.8

### DIFF
--- a/veritas.gemspec
+++ b/veritas.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('abstract_type',       '~> 0.0.2')
   gem.add_runtime_dependency('adamantium',          '~> 0.0.4')
-  gem.add_runtime_dependency('backports',           '~> 2.7.0')
+  gem.add_runtime_dependency('backports',           '~> 2.8.2')
   gem.add_runtime_dependency('descendants_tracker', '~> 0.0.1')
   gem.add_runtime_dependency('equalizer',           '~> 0.0.2')
 end


### PR DESCRIPTION
It should be our policy to bump versions just after each release to
rubygems.org.

My idea is the following:

If I need stuff that is only in the git source, I can set a version
requirement that is unsatisfiable by rubygems. If I forget to include
the git source in Gemfile I'll immediately notice this, because I cannot
bundle anymore.
