### PR TITLE
Add equal value spec for unrelated objects

### DIFF
--- a/spec/unit/veritas/relation/equal_value_spec.rb
+++ b/spec/unit/veritas/relation/equal_value_spec.rb
@@ -104,6 +104,16 @@ describe Relation, '#==' do
     end
   end
 
+  context 'with a different object not responding to #to_set' do
+    let(:other) { Object.new }
+
+    it { should be(false) }
+
+    it 'is symmetric' do
+      should eql(other == object)
+    end
+  end
+
   context 'with a different object having a superset of the headers' do
     let(:other_header) { [ [ :id, Integer ], [ :name, String ] ]       }
     let(:other_body)   { LazyEnumerable.new([ [ 1, 'Dan Kubb' ] ])     }


### PR DESCRIPTION
We fixed a similar issue on equalizer already. IHMO we should use
equalizer also on veritas and this spec is to highlight the problem.

https://github.com/dkubb/equalizer/pull/7

I do not expect this is gets merged, only opening to start the
discussion.

``` ruby
header = Veritas::Relation::Header.coerce([[:foo, String]])
relation = Veritas::Relation.new(header, [])
relation == Object.new # blows up and IMHO should return false
```
