### PR TITLE
Bump backports dependency to ~> 2.8.2

### DIFF
--- a/veritas.gemspec
+++ b/veritas.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('abstract_type',       '~> 0.0.2')
   gem.add_runtime_dependency('adamantium',          '~> 0.0.4')
-  gem.add_runtime_dependency('backports',           '~> 2.7.0')
+  gem.add_runtime_dependency('backports',           '~> 2.8.2')
   gem.add_runtime_dependency('descendants_tracker', '~> 0.0.1')
   gem.add_runtime_dependency('equalizer',           '~> 0.0.2')
 end


### PR DESCRIPTION
I was left with a broken environment because of that, so I decided to just bump in my fork and use that for `dm-mapper` for the time being. I noticed a few failing specs tho. I guess travis will run this PR, so you should see the failures.
