### PR TITLE
Pass header to summaries constructor

### DIFF
--- a/lib/veritas/algebra/summarization.rb
+++ b/lib/veritas/algebra/summarization.rb
@@ -138,9 +138,8 @@ module Veritas
       #
       # @api private
       def summaries
-        header    = summarize_per.header
         summaries = default_summaries
-        operand.each { |tuple| summaries.summarize_by(header, tuple) }
+        operand.each { |tuple| summaries.summarize_by(tuple) }
         summaries.to_hash
       end
 
@@ -150,7 +149,7 @@ module Veritas
       #
       # @api private
       def default_summaries
-        Summaries.new(summarizers)
+        Summaries.new(summarize_per.header, summarizers)
       end
 
       module Methods

--- a/lib/veritas/algebra/summarization/summaries.rb
+++ b/lib/veritas/algebra/summarization/summaries.rb
@@ -9,12 +9,15 @@ module Veritas
 
         # Initialize Summaries
         #
+        # @param [Relation::Header] header
+        #
         # @param [Hash{Symbol => #call}] summarizers
         #
         # @return [undefined]
         #
         # @api private
-        def initialize(summarizers)
+        def initialize(header, summarizers)
+          @header = header
           @summaries = Hash.new
           summarizers.each do |name, summarizer|
             @summaries[name] = Summary.new(summarizer)
@@ -26,15 +29,13 @@ module Veritas
         # @example
         #   summaries = summaries.summarize_by(header, tuple)
         #
-        # @param [Header] header
-        #
         # @param [Tuple] tuple
         #
         # @return [self]
         #
         # @api public
-        def summarize_by(header, tuple)
-          projection = tuple.project(header)
+        def summarize_by(tuple)
+          projection = tuple.project(@header)
           @summaries.each_value do |summary|
             summary.summarize_by(projection, tuple)
           end

--- a/spec/unit/veritas/algebra/summarization/summaries/summarize_by_spec.rb
+++ b/spec/unit/veritas/algebra/summarization/summaries/summarize_by_spec.rb
@@ -3,9 +3,9 @@
 require 'spec_helper'
 
 describe Algebra::Summarization::Summaries, '#summarize_by' do
-  subject { object.summarize_by(header, tuple) }
+  subject { object.summarize_by(tuple) }
 
-  let(:object)       { described_class.new(summarizers)                                 }
+  let(:object)       { described_class.new(header, summarizers)                         }
   let(:summarizers)  { { :count => summarizer }                                         }
   let(:summarizer)   { mock('Summarizer', :call => 1)                                   }
   let(:header)       { Relation::Header.coerce([ [ :id, Integer ] ])                    }

--- a/spec/unit/veritas/algebra/summarization/summaries/to_hash_spec.rb
+++ b/spec/unit/veritas/algebra/summarization/summaries/to_hash_spec.rb
@@ -5,7 +5,8 @@ require 'spec_helper'
 describe Algebra::Summarization::Summaries, '#to_hash' do
   subject { object.to_hash }
 
-  let(:object)      { described_class.new(summarizers) }
+  let(:object)      { described_class.new(header, summarizers) }
+  let(:header)      { mock('Header')                           }
   let(:summarizers) { { :count => mock('Summarizer') } }
 
   it 'matches the expected value' do


### PR DESCRIPTION
This saves a little amount of work per tuple and is more streamlined.
