### PR TITLE
add spec that tests joins against different Tuple classes

### DIFF
--- a/spec/integration/axiom/relation/commutative_tuple_types.rb
+++ b/spec/integration/axiom/relation/commutative_tuple_types.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+# tests Tuple type commutativity
+describe "Axiom::Relation" do
+  class TupleSubclass < Axiom::Tuple
+    def initialize(header, values)
+      super
+    end
+  end
+
+  let(:header_ary)      { header_ary = [[:index, Integer]] }
+  let(:control_tuples)  { [ [ 0 ] ]                        }
+  let(:header)          { header = Axiom::Relation::Header.coerce(header_ary) }
+  let(:axiom_rel)       { Axiom::Relation.new(header, control_tuples) }
+
+  it "should produce one row when natural joined with cloned tuples" do
+    j = axiom_rel.join(Axiom::Relation.new(header, control_tuples.clone))
+    j.count.should == 1
+  end
+
+  it "should produce one row when natural joined with Axiom::Tuple tuples" do
+    j = axiom_rel.join(Axiom::Relation.new(header, [ Axiom::Tuple.new(header, [ 0 ]) ]))
+    j.count.should == 1
+  end
+
+  it "should produce one row when natural joined with TupleSubclass tuples", known_failure: true do
+    j = axiom_rel.join(Axiom::Relation.new(header, [ TupleSubclass.new(header, [ 0 ]) ]))
+    j.count.should == 1
+  end
+end

--- a/spec/integration/axiom/relation/commutative_tuple_types.rb
+++ b/spec/integration/axiom/relation/commutative_tuple_types.rb
@@ -8,9 +8,9 @@ describe "Axiom::Relation" do
     end
   end
 
-  let(:header_ary)      { header_ary = [[:index, Integer]] }
+  let(:header_ary)      { [[:index, Integer]] }
   let(:control_tuples)  { [ [ 0 ] ]                        }
-  let(:header)          { header = Axiom::Relation::Header.coerce(header_ary) }
+  let(:header)          { Axiom::Relation::Header.coerce(header_ary) }
   let(:axiom_rel)       { Axiom::Relation.new(header, control_tuples) }
 
   it "should produce one row when natural joined with cloned tuples" do


### PR DESCRIPTION
this just illustrates some behavior I ran into a long time ago which is probably as-designed. in any case leaving a spec here in case this case is not already covered or you have other comments regarding the equivalence of different Tuple classes.
