### PR TITLE
Update the code to use the 1.9 Hash format

### DIFF
--- a/benchmarks/speed.rb
+++ b/benchmarks/speed.rb
@@ -20,9 +20,9 @@ product  = Relation.new([ [ :age, Integer ] ], [ [ 35 ] ])
 ordered  = relation.sort_by { |r| [ r.id, r.name ] }
 
 RBench.run(TIMES) do
-  column :ruby,  :title => 'Ruby'
-  column :axiom, :title => 'Axiom'
-  column :diff,  :title => 'Diff', :compare => [ :ruby, :axiom ]
+  column :ruby,  title: 'Ruby'
+  column :axiom, title: 'Axiom'
+  column :diff,  title: 'Diff', compare: [ :ruby, :axiom ]
 
   report 'each' do
     ruby  { array.each {}    }

--- a/lib/axiom/aggregate/maximum.rb
+++ b/lib/axiom/aggregate/maximum.rb
@@ -40,7 +40,7 @@ module Axiom
       module Methods
         extend Aliasable
 
-        inheritable_alias(:max => :maximum)
+        inheritable_alias(max: :maximum)
 
         # Return a maximum aggregate function
         #

--- a/lib/axiom/aggregate/mean.rb
+++ b/lib/axiom/aggregate/mean.rb
@@ -60,8 +60,8 @@ module Axiom
         extend Aliasable
 
         inheritable_alias(
-          :average => :mean,
-          :avg     => :mean
+          average: :mean,
+          avg:     :mean
         )
 
         # Return a mean aggregate function

--- a/lib/axiom/aggregate/minimum.rb
+++ b/lib/axiom/aggregate/minimum.rb
@@ -40,7 +40,7 @@ module Axiom
       module Methods
         extend Aliasable
 
-        inheritable_alias(:min => :minimum)
+        inheritable_alias(min: :minimum)
 
         # Return a minimum aggregate function
         #

--- a/lib/axiom/aggregate/standard_deviation.rb
+++ b/lib/axiom/aggregate/standard_deviation.rb
@@ -39,7 +39,7 @@ module Axiom
       module Methods
         extend Aliasable
 
-        inheritable_alias(:stddev => :standard_deviation)
+        inheritable_alias(stddev: :standard_deviation)
 
         # Return a standard deviation aggregate function
         #

--- a/lib/axiom/aggregate/variance.rb
+++ b/lib/axiom/aggregate/variance.rb
@@ -65,7 +65,7 @@ module Axiom
       module Methods
         extend Aliasable
 
-        inheritable_alias(:var => :variance)
+        inheritable_alias(var: :variance)
 
         # Return a variance aggregate function
         #

--- a/lib/axiom/attribute/numeric.rb
+++ b/lib/axiom/attribute/numeric.rb
@@ -11,7 +11,7 @@ module Axiom
 
       DEFAULT_SIZE = (-::Float::INFINITY..::Float::INFINITY).freeze
 
-      inheritable_alias(:range => :size)
+      inheritable_alias(range: :size)
 
       # The Numeric range for a valid value
       #

--- a/lib/axiom/function/numeric/absolute.rb
+++ b/lib/axiom/function/numeric/absolute.rb
@@ -23,7 +23,7 @@ module Axiom
         module Methods
           extend Aliasable
 
-          inheritable_alias(:abs => :absolute)
+          inheritable_alias(abs: :absolute)
 
           # Return an absolute function
           #

--- a/lib/axiom/function/numeric/square_root.rb
+++ b/lib/axiom/function/numeric/square_root.rb
@@ -48,7 +48,7 @@ module Axiom
         module Methods
           extend Aliasable
 
-          inheritable_alias(:sqrt => :square_root)
+          inheritable_alias(sqrt: :square_root)
 
           # Return a square root function
           #

--- a/lib/axiom/relation/header.rb
+++ b/lib/axiom/relation/header.rb
@@ -114,7 +114,7 @@ module Axiom
       # Initialize a Header
       #
       # @example
-      #   header = Header.new(attributes, :keys => [ [ :id ] ])
+      #   header = Header.new(attributes, keys: [ [ :id ] ])
       #
       # @param [Array] attributes
       #
@@ -183,7 +183,7 @@ module Axiom
       #
       # @api public
       def project(attributes)
-        coerce(attributes, :keys => keys.project(attributes))
+        coerce(attributes, keys: keys.project(attributes))
       end
 
       # Return a header with the new attributes added
@@ -201,7 +201,7 @@ module Axiom
       #
       # @api public
       def extend(attributes)
-        new(to_ary + coerce(attributes), :keys => keys)
+        new(to_ary + coerce(attributes), keys: keys)
       end
 
       # Return a header with the attributes renamed
@@ -221,7 +221,7 @@ module Axiom
       def rename(aliases)
         new(
           map { |attribute| aliases[attribute] },
-          :keys => keys.rename(aliases)
+          keys: keys.rename(aliases)
         )
       end
 
@@ -241,7 +241,7 @@ module Axiom
       def intersect(other)
         other      = coerce(other)
         attributes = to_ary & other
-        new(attributes, :keys => (keys | other.keys).project(attributes))
+        new(attributes, keys: (keys | other.keys).project(attributes))
       end
 
       # Return the union of the header with another header
@@ -259,7 +259,7 @@ module Axiom
       # @api public
       def union(other)
         other = coerce(other)
-        new(to_ary | other, :keys => keys & other.keys)
+        new(to_ary | other, keys: keys & other.keys)
       end
 
       # Return the difference of the header with another header
@@ -277,7 +277,7 @@ module Axiom
       # @api public
       def difference(other)
         other = coerce(other)
-        new(to_ary - other, :keys => keys - other.keys)
+        new(to_ary - other, keys: keys - other.keys)
       end
 
       # Convert the Header into an Array

--- a/spec/integration/axiom/relation/efficient_enumerable_spec.rb
+++ b/spec/integration/axiom/relation/efficient_enumerable_spec.rb
@@ -35,7 +35,7 @@ describe Relation do
     end
 
     it '#rename should be efficient' do
-      renamed = relation.rename(:id => :other_id)
+      renamed = relation.rename(id: :other_id)
       sample(renamed).should == [ [ 0 ], [ 1 ], [ 2 ], [ 3 ], [ 4 ] ]
     end
 

--- a/spec/integration/axiom/relation/mutable_enumerator_spec.rb
+++ b/spec/integration/axiom/relation/mutable_enumerator_spec.rb
@@ -38,12 +38,12 @@ describe Relation do
 
     context 'when the enumerator is materialized and restricted' do
       it 'does not freeze the enumerator' do
-        expect { relation.restrict(:id => 1).materialize }.
+        expect { relation.restrict(id: 1).materialize }.
           to_not change(enumerator, :frozen?).from(false)
       end
 
       it 'allows the array to be mutated' do
-        expect { relation.restrict(:id => 1).materialize }.
+        expect { relation.restrict(id: 1).materialize }.
           to change(enumerator, :mutable_array).from([]).to(tuples)
       end
     end

--- a/spec/integration/axiom/relation/writable_relations_spec.rb
+++ b/spec/integration/axiom/relation/writable_relations_spec.rb
@@ -6,13 +6,13 @@ describe Relation do
   context 'Relations are writable' do
     let(:relation) do
       Relation.new(
-        [ [ :id, Integer ], [ :name, String, { :required => false } ] ],
+        [ [ :id, Integer ], [ :name, String, { required: false } ] ],
         [ [ 1, 'John Doe' ], [ 2, 'Jane Doe' ], [ 3, 'Jane Roe' ] ]
       )
     end
 
     it 'Rename#insert and #delete of a disjoint relation are symmetrical' do
-      rename = relation.rename(:id => :other_id)
+      rename = relation.rename(id: :other_id)
       other  = [ [ 4, 'John Doe' ] ]
       rename.insert(other).delete(other).should == rename
     end

--- a/spec/unit/axiom/algebra/extension/class_methods/new_spec.rb
+++ b/spec/unit/axiom/algebra/extension/class_methods/new_spec.rb
@@ -9,13 +9,13 @@ describe Algebra::Extension, '.new' do
   let(:object)  { described_class                                                                                 }
 
   context 'with a unique attribute name provided' do
-    let(:extensions) { { :unique => lambda { |tuple| 1 } } }
+    let(:extensions) { { unique: lambda { |tuple| 1 } } }
 
     it { should be_instance_of(object) }
   end
 
   context 'with a duplicate attribute name provided' do
-    let(:extensions) { { :id => proc {}, :name => proc {} } }
+    let(:extensions) { { id: proc {}, name: proc {} } }
 
     specify { expect { subject }.to raise_error(DuplicateNameError, 'duplicate names: [:id, :name]') }
   end

--- a/spec/unit/axiom/algebra/extension/each_spec.rb
+++ b/spec/unit/axiom/algebra/extension/each_spec.rb
@@ -7,7 +7,7 @@ describe Algebra::Extension, '#each' do
 
   let(:object)     { described_class.new(operand, extensions)             }
   let(:operand)    { Relation.new([ [ :id, Integer ] ], [ [ 1 ], [ 2 ] ]) }
-  let(:extensions) { { :test => lambda { |tuple| 1 } }                    }
+  let(:extensions) { { test: lambda { |tuple| 1 } }                       }
   let(:yields)     { []                                                   }
 
   it_should_behave_like 'an #each method'

--- a/spec/unit/axiom/algebra/extension/eql_spec.rb
+++ b/spec/unit/axiom/algebra/extension/eql_spec.rb
@@ -6,7 +6,7 @@ describe Algebra::Extension, '#eql?' do
   subject { object.eql?(other) }
 
   let(:operand)    { Relation.new([ [ :id, Integer ] ], [ [ 1 ], [ 2 ] ]) }
-  let(:extensions) { { :test => lambda { |tuple| 1 } }                    }
+  let(:extensions) { { test: lambda { |tuple| 1 } }                       }
   let(:object)     { described_class.new(operand, extensions)             }
 
   context 'with the same object' do
@@ -53,7 +53,7 @@ describe Algebra::Extension, '#eql?' do
 
   context 'with an object having different extensions' do
     let(:other_operand)    { operand                                              }
-    let(:other_extensions) { { :text => lambda { |tuple| 2 } }                    }
+    let(:other_extensions) { { text: lambda { |tuple| 2 } }                       }
     let(:other)            { described_class.new(other_operand, other_extensions) }
 
     it { should be(false) }

--- a/spec/unit/axiom/algebra/extension/extensions_spec.rb
+++ b/spec/unit/axiom/algebra/extension/extensions_spec.rb
@@ -6,7 +6,7 @@ describe Algebra::Extension, '#extensions' do
   subject { object.extensions }
 
   let(:operand)    { Relation.new([ [ :id, Integer ] ], [ [ 1 ], [ 2 ] ]) }
-  let(:extensions) { { :test => 1 }                                       }
+  let(:extensions) { { test: 1 }                                          }
   let(:object)     { described_class.new(operand, extensions)             }
 
   it_should_behave_like 'an idempotent method'

--- a/spec/unit/axiom/algebra/extension/header_spec.rb
+++ b/spec/unit/axiom/algebra/extension/header_spec.rb
@@ -6,7 +6,7 @@ describe Algebra::Extension, '#header' do
   subject { object.header }
 
   let(:operand)    { Relation.new([ [ :id, Integer ] ], [ [ 1 ], [ 2 ] ]) }
-  let(:extensions) { { :test => lambda { |tuple| 1 } }                    }
+  let(:extensions) { { test: lambda { |tuple| 1 } }                       }
   let(:object)     { described_class.new(operand, extensions)             }
 
   it_should_behave_like 'an idempotent method'

--- a/spec/unit/axiom/algebra/extension/methods/extend_spec.rb
+++ b/spec/unit/axiom/algebra/extension/methods/extend_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Algebra::Extension::Methods, '#extend' do
   let(:object)          { described_class.new([ [ :id, Integer ] ], LazyEnumerable.new([ [ 1 ] ])) }
   let(:described_class) { Relation                                                                 }
-  let(:extensions)      { { :test => function }                                                    }
+  let(:extensions)      { { test: function }                                                       }
   let(:function)        { object[:id]                                                              }
 
   context 'with extensions' do

--- a/spec/unit/axiom/algebra/extension/operand_spec.rb
+++ b/spec/unit/axiom/algebra/extension/operand_spec.rb
@@ -6,7 +6,7 @@ describe Algebra::Extension, '#operand' do
   subject { object.operand }
 
   let(:operand)    { Relation.new([ [ :id, Integer ] ], [ [ 1 ], [ 2 ] ]) }
-  let(:extensions) { { :test => lambda { |tuple| 1 } }                    }
+  let(:extensions) { { test: lambda { |tuple| 1 } }                       }
   let(:object)     { described_class.new(operand, extensions)             }
 
   it_should_behave_like 'an idempotent method'

--- a/spec/unit/axiom/algebra/projection/delete_spec.rb
+++ b/spec/unit/axiom/algebra/projection/delete_spec.rb
@@ -43,7 +43,7 @@ describe Algebra::Projection, '#delete' do
   context 'when optional attributes are removed' do
     let(:operand)     { Relation.new(base_header, LazyEnumerable.new([ [ 1, 'John Doe' ] ])) }
     let(:other)       { Relation.new(header,      LazyEnumerable.new([ [ 2             ] ])) }
-    let(:base_header) { [ [ :id, Integer ], [ :name, String, { :required => false } ] ]      }
+    let(:base_header) { [ [ :id, Integer ], [ :name, String, { required: false } ] ]         }
 
     it_should_behave_like 'Algebra::Projection#delete'
   end
@@ -51,7 +51,7 @@ describe Algebra::Projection, '#delete' do
   context 'when the other header does not match the projection' do
     let(:operand)     { Relation.new(base_header, LazyEnumerable.new([ [ 1, 'John Doe' ] ])) }
     let(:other)       { Relation.new(base_header, LazyEnumerable.new([ [ 2, 'Jane Doe' ] ])) }
-    let(:base_header) { [ [ :id, Integer ], [ :name, String, { :required => false } ] ]      }
+    let(:base_header) { [ [ :id, Integer ], [ :name, String, { required: false } ] ]         }
 
     specify { expect { subject }.to raise_error(InvalidHeaderError, 'the headers must be equivalent') }
   end

--- a/spec/unit/axiom/algebra/projection/insert_spec.rb
+++ b/spec/unit/axiom/algebra/projection/insert_spec.rb
@@ -43,7 +43,7 @@ describe Algebra::Projection, '#insert' do
   context 'when optional attributes are removed' do
     let(:operand)     { Relation.new(base_header, LazyEnumerable.new([ [ 1, 'John Doe' ] ])) }
     let(:other)       { Relation.new(header,      LazyEnumerable.new([ [ 2             ] ])) }
-    let(:base_header) { [ [ :id, Integer ], [ :name, String, { :required => false } ] ]      }
+    let(:base_header) { [ [ :id, Integer ], [ :name, String, { required: false } ] ]         }
 
     it_should_behave_like 'Algebra::Projection#insert'
   end
@@ -59,7 +59,7 @@ describe Algebra::Projection, '#insert' do
   context 'when the other header does not match the projection' do
     let(:operand)     { Relation.new(base_header, LazyEnumerable.new([ [ 1, 'John Doe' ] ])) }
     let(:other)       { Relation.new(base_header, LazyEnumerable.new([ [ 2, 'Jane Doe' ] ])) }
-    let(:base_header) { [ [ :id, Integer ], [ :name, String, { :required => false } ] ]      }
+    let(:base_header) { [ [ :id, Integer ], [ :name, String, { required: false } ] ]         }
 
     specify { expect { subject }.to raise_error(InvalidHeaderError, 'the headers must be equivalent') }
   end

--- a/spec/unit/axiom/algebra/rename/delete_spec.rb
+++ b/spec/unit/axiom/algebra/rename/delete_spec.rb
@@ -8,7 +8,7 @@ describe Algebra::Rename, '#delete' do
   let(:object)         { described_class.new(operand, aliases)                                    }
   let(:operand)        { Relation.new([ [ :id, Integer ] ], LazyEnumerable.new([ [ 1 ], [ 2 ] ])) }
   let(:other_relation) { Relation.new(header,               LazyEnumerable.new([ [ 2 ]        ])) }
-  let(:aliases)        { described_class::Aliases.coerce(operand.header, :id => :other_id)        }
+  let(:aliases)        { described_class::Aliases.coerce(operand.header, id: :other_id)           }
   let(:header)         { [ [ :other_id, Integer ] ]                                               }
 
   shared_examples_for 'Algebra::Rename#delete' do

--- a/spec/unit/axiom/algebra/rename/directions_spec.rb
+++ b/spec/unit/axiom/algebra/rename/directions_spec.rb
@@ -6,7 +6,7 @@ describe Algebra::Rename, '#directions' do
   subject { object.directions }
 
   let(:relation) { Relation.new([ [ :id, Integer ] ], LazyEnumerable.new) }
-  let(:object)   { described_class.new(operand, :id => :other_id)         }
+  let(:object)   { described_class.new(operand, id: :other_id)            }
 
   context 'containing a relation' do
     let(:operand) { relation }

--- a/spec/unit/axiom/algebra/rename/each_spec.rb
+++ b/spec/unit/axiom/algebra/rename/each_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 describe Algebra::Rename, '#each' do
   subject { object.each { |tuple| yields << tuple } }
 
-  let(:object)   { described_class.new(relation, :id => :other_id) }
-  let(:relation) { Relation.new([ [ :id, Integer ] ], [ [ 1 ] ])   }
-  let(:yields)   { []                                              }
+  let(:object)   { described_class.new(relation, id: :other_id)  }
+  let(:relation) { Relation.new([ [ :id, Integer ] ], [ [ 1 ] ]) }
+  let(:yields)   { []                                            }
 
   it_should_behave_like 'an #each method'
 

--- a/spec/unit/axiom/algebra/rename/eql_spec.rb
+++ b/spec/unit/axiom/algebra/rename/eql_spec.rb
@@ -6,7 +6,7 @@ describe Algebra::Rename, '#eql?' do
   subject { object.eql?(other) }
 
   let(:operand) { Relation.new([ [ :id, Integer ] ], [ [ 1 ] ]) }
-  let(:aliases) { { :id => :other_id }                          }
+  let(:aliases) { { id: :other_id }                             }
   let(:object)  { described_class.new(operand, aliases)         }
 
   context 'with the same object' do
@@ -53,7 +53,7 @@ describe Algebra::Rename, '#eql?' do
 
   context 'with an object having different aliases' do
     let(:other_operand) { operand                                           }
-    let(:other_aliases) { { :id => :another_id }                            }
+    let(:other_aliases) { { id: :another_id }                               }
     let(:other)         { described_class.new(other_operand, other_aliases) }
 
     it { should be(false) }

--- a/spec/unit/axiom/algebra/rename/hash_spec.rb
+++ b/spec/unit/axiom/algebra/rename/hash_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 describe Algebra::Rename, '#hash' do
   subject { object.hash }
 
-  let(:operand) { Relation.new([ [ :id, Integer ] ], [ [ 1 ] ])  }
-  let(:aliases) { described_class::Aliases.new(:id => :other_id) }
-  let(:object)  { described_class.new(operand, aliases)          }
+  let(:operand) { Relation.new([ [ :id, Integer ] ], [ [ 1 ] ]) }
+  let(:aliases) { described_class::Aliases.new(id: :other_id)   }
+  let(:object)  { described_class.new(operand, aliases)         }
 
   it_should_behave_like 'a hash method'
 

--- a/spec/unit/axiom/algebra/rename/header_spec.rb
+++ b/spec/unit/axiom/algebra/rename/header_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe Algebra::Rename, '#header' do
   subject { object.header }
 
-  let(:relation) { Relation.new([ [ :id, Integer ] ], [ [ 1 ] ])   }
-  let(:object)   { described_class.new(relation, :id => :other_id) }
+  let(:relation) { Relation.new([ [ :id, Integer ] ], [ [ 1 ] ]) }
+  let(:object)   { described_class.new(relation, id: :other_id)  }
 
   it_should_behave_like 'an idempotent method'
 

--- a/spec/unit/axiom/algebra/rename/insert_spec.rb
+++ b/spec/unit/axiom/algebra/rename/insert_spec.rb
@@ -8,7 +8,7 @@ describe Algebra::Rename, '#insert' do
   let(:object)         { described_class.new(operand, aliases)                             }
   let(:operand)        { Relation.new([ [ :id, Integer ] ], LazyEnumerable.new([ [ 1 ] ])) }
   let(:other_relation) { Relation.new(header,               LazyEnumerable.new([ [ 2 ] ])) }
-  let(:aliases)        { described_class::Aliases.coerce(operand.header, :id => :other_id) }
+  let(:aliases)        { described_class::Aliases.coerce(operand.header, id: :other_id)    }
   let(:header)         { [ [ :other_id, Integer ] ]                                        }
 
   shared_examples_for 'Algebra::Rename#insert' do

--- a/spec/unit/axiom/algebra/rename/methods/rename_spec.rb
+++ b/spec/unit/axiom/algebra/rename/methods/rename_spec.rb
@@ -7,7 +7,7 @@ describe Algebra::Rename::Methods, '#rename' do
 
   let(:described_class) { Relation                                                          }
   let(:attribute)       { Attribute::Integer.new(:id)                                       }
-  let(:aliases)         { { :id => :other_id }                                              }
+  let(:aliases)         { { id: :other_id }                                                 }
   let(:object)          { described_class.new([ attribute ], LazyEnumerable.new([ [ 1 ] ])) }
 
   it { should be_instance_of(Algebra::Rename) }

--- a/spec/unit/axiom/algebra/restriction/methods/restrict_spec.rb
+++ b/spec/unit/axiom/algebra/restriction/methods/restrict_spec.rb
@@ -44,7 +44,7 @@ describe Algebra::Restriction::Methods, '#restrict' do
   context 'with a Hash' do
     subject { object.restrict(predicate) }
 
-    let(:predicate) { { :id => 1, :name => 'Dan Kubb' } }
+    let(:predicate) { { id: 1, name: 'Dan Kubb' } }
 
     it { should be_instance_of(Algebra::Restriction) }
 

--- a/spec/unit/axiom/algebra/summarization/delete_spec.rb
+++ b/spec/unit/axiom/algebra/summarization/delete_spec.rb
@@ -9,7 +9,7 @@ describe Algebra::Summarization, '#delete' do
   let(:other)        { stub('other')                                           }
   let(:operand)      { Relation.new([ [ :id, Integer ] ], [])                  }
   let(:summarize_by) { operand.project([])                                     }
-  let(:summarizers)  { { :test => 1 }                                          }
+  let(:summarizers)  { { test: 1 }                                             }
 
   specify { expect { subject }.to raise_error(ImmutableRelationError, 'deleting from a summarization is impossible') }
 end

--- a/spec/unit/axiom/algebra/summarization/each_spec.rb
+++ b/spec/unit/axiom/algebra/summarization/each_spec.rb
@@ -7,7 +7,7 @@ describe Algebra::Summarization, '#each' do
 
   let(:object)      { described_class.new(operand, operand.project([]), summarizers) }
   let(:operand)     { Relation.new([ [ :id, Integer ] ], [ [ 1 ], [ 2 ] ])           }
-  let(:summarizers) { { :count => lambda { |acc, tuple| acc.to_i + 1 } }             }
+  let(:summarizers) { { count: lambda { |acc, tuple| acc.to_i + 1 } }                }
   let(:yields)      { []                                                             }
 
   it_should_behave_like 'an #each method'

--- a/spec/unit/axiom/algebra/summarization/eql_spec.rb
+++ b/spec/unit/axiom/algebra/summarization/eql_spec.rb
@@ -7,7 +7,7 @@ describe Algebra::Summarization, '#eql?' do
 
   let(:operand)      { Relation.new([ [ :id, Integer ] ], [ [ 1 ], [ 2 ] ])    }
   let(:summarize_by) { operand.project([])                                     }
-  let(:summarizers)  { { :count => lambda { |acc, tuple| acc.to_i + 1 } }      }
+  let(:summarizers)  { { count: lambda { |acc, tuple| acc.to_i + 1 } }         }
   let(:object)       { described_class.new(operand, summarize_by, summarizers) }
 
   context 'with the same object' do

--- a/spec/unit/axiom/algebra/summarization/hash_spec.rb
+++ b/spec/unit/axiom/algebra/summarization/hash_spec.rb
@@ -7,7 +7,7 @@ describe Algebra::Summarization, '#hash' do
 
   let(:operand)      { Relation.new([ [ :id, Integer ] ], [ [ 1 ], [ 2 ] ])    }
   let(:summarize_by) { operand.project([])                                     }
-  let(:summarizers)  { { :count => lambda { |acc, tuple| acc.to_i + 1 } }      }
+  let(:summarizers)  { { count: lambda { |acc, tuple| acc.to_i + 1 } }         }
   let(:object)       { described_class.new(operand, summarize_by, summarizers) }
 
   it_should_behave_like 'a hash method'

--- a/spec/unit/axiom/algebra/summarization/header_spec.rb
+++ b/spec/unit/axiom/algebra/summarization/header_spec.rb
@@ -6,7 +6,7 @@ describe Algebra::Summarization, '#header' do
   subject { object.header }
 
   let(:operand)     { Relation.new([ [ :id, Integer ] ], [ [ 1 ], [ 2 ] ]) }
-  let(:summarizers) { { :test => lambda { |acc, tuple| 1 } }               }
+  let(:summarizers) { { test: lambda { |acc, tuple| 1 } }                  }
   let(:object)      { described_class.new(operand, TABLE_DEE, summarizers) }
 
   it_should_behave_like 'an idempotent method'

--- a/spec/unit/axiom/algebra/summarization/insert_spec.rb
+++ b/spec/unit/axiom/algebra/summarization/insert_spec.rb
@@ -9,7 +9,7 @@ describe Algebra::Summarization, '#insert' do
   let(:other)        { stub('other')                                           }
   let(:operand)      { Relation.new([ [ :id, Integer ] ], [])                  }
   let(:summarize_by) { operand.project([])                                     }
-  let(:summarizers)  { { :test => 1 }                                          }
+  let(:summarizers)  { { test: 1 }                                             }
 
   specify { expect { subject }.to raise_error(ImmutableRelationError, 'inserting into a summarization is impossible') }
 end

--- a/spec/unit/axiom/algebra/summarization/summaries/summarize_by_spec.rb
+++ b/spec/unit/axiom/algebra/summarization/summaries/summarize_by_spec.rb
@@ -6,8 +6,8 @@ describe Algebra::Summarization::Summaries, '#summarize_by' do
   subject { object.summarize_by(tuple) }
 
   let(:object)       { described_class.new(header, summarizers)                         }
-  let(:summarizers)  { { :count => summarizer }                                         }
-  let(:summarizer)   { mock('Summarizer', :call => 1)                                   }
+  let(:summarizers)  { { count: summarizer }                                            }
+  let(:summarizer)   { mock('Summarizer', call: 1)                                      }
   let(:header)       { Relation::Header.coerce([ [ :id, Integer ] ])                    }
   let(:tuple_header) { Relation::Header.coerce([ [ :id, Integer ], [ :name, String ] ]) }
   let(:tuple)        { Tuple.new(tuple_header, [ 1, 'Dan Kubb' ])                       }

--- a/spec/unit/axiom/algebra/summarization/summaries/to_hash_spec.rb
+++ b/spec/unit/axiom/algebra/summarization/summaries/to_hash_spec.rb
@@ -7,7 +7,7 @@ describe Algebra::Summarization::Summaries, '#to_hash' do
 
   let(:object)      { described_class.new(header, summarizers) }
   let(:header)      { mock('Header')                           }
-  let(:summarizers) { { :count => mock('Summarizer') }         }
+  let(:summarizers) { { count: mock('Summarizer') }            }
 
   it 'matches the expected value' do
     key, value = subject.first

--- a/spec/unit/axiom/algebra/summarization/summarize_per_spec.rb
+++ b/spec/unit/axiom/algebra/summarization/summarize_per_spec.rb
@@ -6,7 +6,7 @@ describe Algebra::Summarization, '#summarize_per' do
   subject { object.summarize_per }
 
   let(:operand)     { Relation.new([ [ :id, Integer ] ], [ [ 1 ], [ 2 ] ]) }
-  let(:summarizers) { { :test => lambda { |acc, tuple| 1 } }               }
+  let(:summarizers) { { test: lambda { |acc, tuple| 1 } }                  }
   let(:object)      { described_class.new(operand, TABLE_DEE, summarizers) }
 
   it_should_behave_like 'an idempotent method'

--- a/spec/unit/axiom/algebra/summarization/summarizers_spec.rb
+++ b/spec/unit/axiom/algebra/summarization/summarizers_spec.rb
@@ -6,7 +6,7 @@ describe Algebra::Summarization, '#summarizers' do
   subject { object.summarizers }
 
   let(:operand)     { Relation.new([ [ :id, Integer ] ], [ [ 1 ], [ 2 ] ]) }
-  let(:summarizers) { { :test => lambda { |acc, tuple| 1 } }               }
+  let(:summarizers) { { test: lambda { |acc, tuple| 1 } }                  }
   let(:object)      { described_class.new(operand, TABLE_DEE, summarizers) }
 
   it_should_behave_like 'an idempotent method'

--- a/spec/unit/axiom/aliasable/inheritable_alias_spec.rb
+++ b/spec/unit/axiom/aliasable/inheritable_alias_spec.rb
@@ -6,7 +6,7 @@ require File.expand_path('../fixtures/classes', __FILE__)
 describe Aliasable, '#inheritable_alias' do
   subject { object.inheritable_alias(aliases) }
 
-  let(:aliases)   { { :other => :test }               }
+  let(:aliases)   { { other: :test }                  }
   let(:object)    { Class.new(AliasableSpecs::Object) }
   let(:aliasable) { object.new                        }
 

--- a/spec/unit/axiom/attribute/class_methods/coerce_spec.rb
+++ b/spec/unit/axiom/attribute/class_methods/coerce_spec.rb
@@ -22,7 +22,7 @@ describe Attribute, '.coerce' do
   end
 
   context 'when the argument responds to #to_ary and includes options' do
-    let(:argument) { [ :id, Integer, { :required => false } ] }
+    let(:argument) { [ :id, Integer, { required: false } ] }
 
     it { should be_instance_of(Attribute::Integer) }
 
@@ -66,7 +66,7 @@ describe Attribute::Boolean, '.coerce' do
   end
 
   context 'when the argument responds to #to_ary and includes options' do
-    let(:argument) { [ :id, Integer, { :required => false } ] }
+    let(:argument) { [ :id, Integer, { required: false } ] }
 
     it { should be_instance_of(Attribute::Integer) }
 

--- a/spec/unit/axiom/attribute/eql_spec.rb
+++ b/spec/unit/axiom/attribute/eql_spec.rb
@@ -50,7 +50,7 @@ describe Attribute, '#eql?' do
   end
 
   context 'with an object having a different required option' do
-    let(:other) { described_class.new(name, :required => false) }
+    let(:other) { described_class.new(name, required: false) }
 
     it { should be(false) }
 

--- a/spec/unit/axiom/attribute/equality_operator_spec.rb
+++ b/spec/unit/axiom/attribute/equality_operator_spec.rb
@@ -50,7 +50,7 @@ describe Attribute, '#==' do
   end
 
   context 'with an object having a different required option' do
-    let(:other) { described_class.new(name, :required => false) }
+    let(:other) { described_class.new(name, required: false) }
 
     it { should be(false) }
 

--- a/spec/unit/axiom/attribute/float/size_spec.rb
+++ b/spec/unit/axiom/attribute/float/size_spec.rb
@@ -13,7 +13,7 @@ require 'spec_helper'
     end
 
     context 'with :size option passed to constructor' do
-      let(:object) { described_class.new(:id, :size => 1.0..100.0) }
+      let(:object) { described_class.new(:id, size: 1.0..100.0) }
 
       it { should eql(1.0..100.0) }
     end

--- a/spec/unit/axiom/attribute/hash_spec.rb
+++ b/spec/unit/axiom/attribute/hash_spec.rb
@@ -8,7 +8,7 @@ describe Attribute, '#hash' do
   let(:described_class) { Class.new(Attribute)               }
   let(:name)            { :name                              }
   let(:required)        { true                               }
-  let(:options)         { { :required => required }          }
+  let(:options)         { { required: required }             }
   let(:object)          { described_class.new(name, options) }
 
   it_should_behave_like 'a hash method'

--- a/spec/unit/axiom/attribute/numeric/eql_spec.rb
+++ b/spec/unit/axiom/attribute/numeric/eql_spec.rb
@@ -50,7 +50,7 @@ describe Attribute::Numeric, '#eql?' do
   end
 
   context 'with an object having a different required option' do
-    let(:other) { described_class.new(name, :required => false) }
+    let(:other) { described_class.new(name, required: false) }
 
     it { should be(false) }
 
@@ -60,7 +60,7 @@ describe Attribute::Numeric, '#eql?' do
   end
 
   context 'with an object having a different size' do
-    let(:other) { described_class.new(name, :size => 0..100) }
+    let(:other) { described_class.new(name, size: 0..100) }
 
     it { should be(false) }
 

--- a/spec/unit/axiom/attribute/numeric/equality_operator_spec.rb
+++ b/spec/unit/axiom/attribute/numeric/equality_operator_spec.rb
@@ -50,7 +50,7 @@ describe Attribute::Numeric, '#==' do
   end
 
   context 'with an object having a different required option' do
-    let(:other) { described_class.new(name, :required => false) }
+    let(:other) { described_class.new(name, required: false) }
 
     it { should be(false) }
 
@@ -60,7 +60,7 @@ describe Attribute::Numeric, '#==' do
   end
 
   context 'with an object having a different size' do
-    let(:other) { described_class.new(name, :size => 0..100) }
+    let(:other) { described_class.new(name, size: 0..100) }
 
     it { should be(false) }
 

--- a/spec/unit/axiom/attribute/numeric/hash_spec.rb
+++ b/spec/unit/axiom/attribute/numeric/hash_spec.rb
@@ -5,11 +5,11 @@ require 'spec_helper'
 describe Attribute::Numeric, '#hash' do
   subject { object.hash }
 
-  let(:object)     { described_class.new(name, options)       }
-  let(:name)       { :name                                    }
-  let(:options)    { { :required => required, :size => size } }
-  let(:required)   { true                                     }
-  let(:size)       { 0..10                                    }
+  let(:object)     { described_class.new(name, options) }
+  let(:name)       { :name                              }
+  let(:options)    { { required: required, size: size } }
+  let(:required)   { true                               }
+  let(:size)       { 0..10                              }
 
   it_should_behave_like 'a hash method'
 

--- a/spec/unit/axiom/attribute/numeric/size_spec.rb
+++ b/spec/unit/axiom/attribute/numeric/size_spec.rb
@@ -15,7 +15,7 @@ require 'spec_helper'
     end
 
     context 'with a :size option passed to constructor that is inclusive' do
-      let(:object) { described_class.new(:id, :size => 1..100) }
+      let(:object) { described_class.new(:id, size: 1..100) }
 
       it_should_behave_like 'an idempotent method'
 
@@ -23,7 +23,7 @@ require 'spec_helper'
     end
 
     context 'with a :size option passed to constructor that is exclusive' do
-      let(:object) { described_class.new(:id, :size => 1...101) }
+      let(:object) { described_class.new(:id, size: 1...101) }
 
       it_should_behave_like 'an idempotent method'
 

--- a/spec/unit/axiom/attribute/numeric/valid_value_predicate_spec.rb
+++ b/spec/unit/axiom/attribute/numeric/valid_value_predicate_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Attribute::Numeric, '#valid_value?' do
   subject { object.valid_value?(value) }
 
-  let(:object) { described_class.new(:numeric, :size => 1..50) }
+  let(:object) { described_class.new(:numeric, size: 1..50) }
 
   context 'with a numeric value' do
     context 'that is within the allowed size range' do

--- a/spec/unit/axiom/attribute/rename_spec.rb
+++ b/spec/unit/axiom/attribute/rename_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe Attribute, '#rename' do
   subject { object.rename(name) }
 
-  let(:described_class) { Class.new(Attribute)                           }
-  let(:object)          { described_class.new(:name, :required => false) }
+  let(:described_class) { Class.new(Attribute)                        }
+  let(:object)          { described_class.new(:name, required: false) }
 
   context 'when the new name is the same' do
     let(:name) { object.name }

--- a/spec/unit/axiom/attribute/required_predicate_spec.rb
+++ b/spec/unit/axiom/attribute/required_predicate_spec.rb
@@ -13,14 +13,14 @@ describe Attribute, '#required?' do
     it { should be(true) }
   end
 
-  context 'with :required => true option passed to constructor' do
-    let(:object) { described_class.new(:name, :required => true) }
+  context 'with required: true option passed to constructor' do
+    let(:object) { described_class.new(:name, required: true) }
 
     it { should be(true) }
   end
 
-  context 'with :required => false option passed to constructor' do
-    let(:object) { described_class.new(:name, :required => false) }
+  context 'with required: false option passed to constructor' do
+    let(:object) { described_class.new(:name, required: false) }
 
     it { should be(false) }
   end

--- a/spec/unit/axiom/attribute/string/eql_spec.rb
+++ b/spec/unit/axiom/attribute/string/eql_spec.rb
@@ -50,7 +50,7 @@ describe Attribute::String, '#eql?' do
   end
 
   context 'with an object having a different required option' do
-    let(:other) { described_class.new(name, :required => false) }
+    let(:other) { described_class.new(name, required: false) }
 
     it { should be(false) }
 
@@ -60,7 +60,7 @@ describe Attribute::String, '#eql?' do
   end
 
   context 'with an object having a different min_length' do
-    let(:other) { described_class.new(name, :min_length => 1) }
+    let(:other) { described_class.new(name, min_length: 1) }
 
     it { should be(false) }
 
@@ -70,7 +70,7 @@ describe Attribute::String, '#eql?' do
   end
 
   context 'with an object having a different max_length' do
-    let(:other) { described_class.new(name, :max_length => 100) }
+    let(:other) { described_class.new(name, max_length: 100) }
 
     it { should be(false) }
 

--- a/spec/unit/axiom/attribute/string/equality_operator_spec.rb
+++ b/spec/unit/axiom/attribute/string/equality_operator_spec.rb
@@ -50,7 +50,7 @@ describe Attribute::String, '#==' do
   end
 
   context 'with an object having a different required option' do
-    let(:other) { described_class.new(name, :required => false) }
+    let(:other) { described_class.new(name, required: false) }
 
     it { should be(false) }
 
@@ -60,7 +60,7 @@ describe Attribute::String, '#==' do
   end
 
   context 'with an object having a different min_length' do
-    let(:other) { described_class.new(name, :min_length => 1) }
+    let(:other) { described_class.new(name, min_length: 1) }
 
     it { should be(false) }
 
@@ -70,7 +70,7 @@ describe Attribute::String, '#==' do
   end
 
   context 'with an object having a different max_length' do
-    let(:other) { described_class.new(name, :max_length => 100) }
+    let(:other) { described_class.new(name, max_length: 100) }
 
     it { should be(false) }
 

--- a/spec/unit/axiom/attribute/string/hash_spec.rb
+++ b/spec/unit/axiom/attribute/string/hash_spec.rb
@@ -13,9 +13,9 @@ describe Attribute::String, '#hash' do
 
   let(:options) do
     {
-      :required   => required,
-      :min_length => min_length,
-      :max_length => max_length,
+      required:   required,
+      min_length: min_length,
+      max_length: max_length,
     }
   end
 

--- a/spec/unit/axiom/attribute/string/max_length_spec.rb
+++ b/spec/unit/axiom/attribute/string/max_length_spec.rb
@@ -12,8 +12,8 @@ describe Attribute::String, '#max_length' do
   end
 
   context 'with :length option passed to constructor' do
-    let(:max_length) { 100                                                   }
-    let(:object)     { described_class.new(:name, :max_length => max_length) }
+    let(:max_length) { 100                                                }
+    let(:object)     { described_class.new(:name, max_length: max_length) }
 
     it { should == max_length }
   end

--- a/spec/unit/axiom/attribute/string/min_length_spec.rb
+++ b/spec/unit/axiom/attribute/string/min_length_spec.rb
@@ -12,8 +12,8 @@ describe Attribute::String, '#min_length' do
   end
 
   context 'with :length option passed to constructor' do
-    let(:min_length) { 1                                                     }
-    let(:object)     { described_class.new(:name, :min_length => min_length) }
+    let(:min_length) { 1                                                  }
+    let(:object)     { described_class.new(:name, min_length: min_length) }
 
     it { should == min_length }
   end

--- a/spec/unit/axiom/attribute/string/valid_value_predicate_spec.rb
+++ b/spec/unit/axiom/attribute/string/valid_value_predicate_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Attribute::String, '#valid_value?' do
   subject { object.valid_value?(value) }
 
-  let(:object) { described_class.new(:string, :min_length => 1, :max_length => 50) }
+  let(:object) { described_class.new(:string, min_length: 1, max_length: 50) }
 
   context 'with a string value' do
     context 'that is within the allowed length range' do

--- a/spec/unit/axiom/attribute/valid_value_predicate_spec.rb
+++ b/spec/unit/axiom/attribute/valid_value_predicate_spec.rb
@@ -25,7 +25,7 @@ describe Attribute, '#valid_value?' do
     end
 
     context 'and the attribute not required' do
-      let(:object) { described_class.new(:name, :required => false) }
+      let(:object) { described_class.new(:name, required: false) }
 
       it { should be(true) }
     end

--- a/spec/unit/axiom/equalizer/class_method/new_spec.rb
+++ b/spec/unit/axiom/equalizer/class_method/new_spec.rb
@@ -12,7 +12,7 @@ describe Axiom::Equalizer, '.new' do
 
     before do
       # specify the class #name method
-      klass.stub(:name => name)
+      klass.stub(name: name)
       klass.send(:include, subject)
     end
 
@@ -84,7 +84,7 @@ describe Axiom::Equalizer, '.new' do
 
     before do
       # specify the class #inspect method
-      klass.stub(:name => nil, :inspect => name)
+      klass.stub(name: nil, inspect: name)
       klass.send(:include, subject)
     end
 

--- a/spec/unit/axiom/function/binary/rename_spec.rb
+++ b/spec/unit/axiom/function/binary/rename_spec.rb
@@ -6,12 +6,12 @@ require File.expand_path('../fixtures/classes', __FILE__)
 describe Function::Binary, '#rename' do
   subject { object.rename(aliases) }
 
-  let(:described_class) { BinarySpecs::Object                                       }
-  let(:attribute)       { Attribute::Integer.new(:id)                               }
-  let(:other)           { attribute.rename(:other_id)                               }
-  let(:header)          { Relation::Header.new([ attribute ])                       }
-  let(:aliases)         { Algebra::Rename::Aliases.coerce(header, :id => :other_id) }
-  let(:object)          { described_class.new(left, right)                          }
+  let(:described_class) { BinarySpecs::Object                                    }
+  let(:attribute)       { Attribute::Integer.new(:id)                            }
+  let(:other)           { attribute.rename(:other_id)                            }
+  let(:header)          { Relation::Header.new([ attribute ])                    }
+  let(:aliases)         { Algebra::Rename::Aliases.coerce(header, id: :other_id) }
+  let(:object)          { described_class.new(left, right)                       }
 
   context 'left and right are renamed' do
     let(:left)  { attribute.eq(1) }

--- a/spec/unit/axiom/function/class_methods/rename_attributes_spec.rb
+++ b/spec/unit/axiom/function/class_methods/rename_attributes_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 describe Function, '.rename_attributes' do
   subject { object.rename_attributes(operand, aliases) }
 
-  let(:object)  { described_class                                           }
-  let(:header)  { Relation::Header.coerce([ [ :id, Integer ] ])             }
-  let(:aliases) { Algebra::Rename::Aliases.coerce(header, :id => :other_id) }
+  let(:object)  { described_class                                        }
+  let(:header)  { Relation::Header.coerce([ [ :id, Integer ] ])          }
+  let(:aliases) { Algebra::Rename::Aliases.coerce(header, id: :other_id) }
 
   context 'with an attribute' do
     let(:operand) { header[:id] }

--- a/spec/unit/axiom/function/proposition/inverse_spec.rb
+++ b/spec/unit/axiom/function/proposition/inverse_spec.rb
@@ -5,13 +5,13 @@ require 'spec_helper'
 describe Function::Proposition, '#inverse' do
   subject { object.inverse }
 
-  let(:described_class)  { Class.new(Function::Proposition)                     }
-  let(:inverse_class)    { mock('Inverse Class', :instance => inverse_instance) }
-  let(:inverse_instance) { mock('Inverse Instance')                             }
-  let(:object)           { described_class.new                                  }
+  let(:described_class)  { Class.new(Function::Proposition)                  }
+  let(:inverse_class)    { mock('Inverse Class', instance: inverse_instance) }
+  let(:inverse_instance) { mock('Inverse Instance')                          }
+  let(:object)           { described_class.new                               }
 
   before do
-    described_class.stub(:inverse => inverse_class)
+    described_class.stub(inverse: inverse_class)
   end
 
   it 'calls .inverse on the class' do

--- a/spec/unit/axiom/function/unary/callable/call_spec.rb
+++ b/spec/unit/axiom/function/unary/callable/call_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 describe Function::Unary::Callable, '#call' do
   subject { object.call(value) }
 
-  let(:object)    { mock('object', :operation => :op).extend(self.class.described_class) }
-  let(:value)     { mock('value', :send => response)                                     }
-  let(:response)  { mock('response')                                                     }
+  let(:object)    { mock('object', operation: :op).extend(self.class.described_class) }
+  let(:value)     { mock('value', send: response)                                     }
+  let(:response)  { mock('response')                                                  }
 
   it { should equal(response) }
 

--- a/spec/unit/axiom/function/unary/rename_spec.rb
+++ b/spec/unit/axiom/function/unary/rename_spec.rb
@@ -6,12 +6,12 @@ require File.expand_path('../fixtures/classes', __FILE__)
 describe Function::Unary, '#rename' do
   subject { object.rename(aliases) }
 
-  let(:described_class) { UnarySpecs::Object                                        }
-  let(:attribute)       { Attribute::Integer.new(:id)                               }
-  let(:other)           { attribute.rename(:other_id)                               }
-  let(:header)          { Relation::Header.new([ attribute ])                       }
-  let(:aliases)         { Algebra::Rename::Aliases.coerce(header, :id => :other_id) }
-  let(:object)          { described_class.new(operand)                              }
+  let(:described_class) { UnarySpecs::Object                                     }
+  let(:attribute)       { Attribute::Integer.new(:id)                            }
+  let(:other)           { attribute.rename(:other_id)                            }
+  let(:header)          { Relation::Header.new([ attribute ])                    }
+  let(:aliases)         { Algebra::Rename::Aliases.coerce(header, id: :other_id) }
+  let(:object)          { described_class.new(operand)                           }
 
   context 'operand is renamed' do
     let(:operand) { attribute.eq(1) }

--- a/spec/unit/axiom/relation/header/class_methods/coerce_spec.rb
+++ b/spec/unit/axiom/relation/header/class_methods/coerce_spec.rb
@@ -90,7 +90,7 @@ describe Relation::Header, '.coerce' do
   context 'with options' do
     subject { object.coerce(array, options) }
 
-    let(:options) { { :keys => [ array ] } }
+    let(:options) { { keys: [ array ] } }
 
     it { should be_instance_of(object) }
 

--- a/spec/unit/axiom/relation/header/difference_spec.rb
+++ b/spec/unit/axiom/relation/header/difference_spec.rb
@@ -45,7 +45,7 @@ require 'spec_helper'
 
     context 'when the keys are equivalent' do
       let(:other_attributes) { [ [ :id, Integer ], [ :name, String ], [ :age, Integer ] ] }
-      let(:options)          { { :keys => keys }                                          }
+      let(:options)          { { keys: keys }                                             }
 
       it { should be_instance_of(described_class) }
 
@@ -56,8 +56,8 @@ require 'spec_helper'
 
     context 'when the keys intersect' do
       let(:other_attributes) { [ [ :id, Integer ], [ :name, String ], [ :age, Integer ] ] }
-      let(:options)          { { :keys => keys }                                          }
-      let(:other_options)    { { :keys => other_keys }                                    }
+      let(:options)          { { keys: keys }                                             }
+      let(:other_options)    { { keys: other_keys }                                       }
 
       let(:other_keys) do
         Relation::Keys.coerce([
@@ -75,8 +75,8 @@ require 'spec_helper'
 
     context 'when the keys do not intersect' do
       let(:other_attributes) { [ [ :id, Integer ], [ :name, String ], [ :age, Integer ] ] }
-      let(:options)          { { :keys => keys }                                          }
-      let(:other_options)    { { :keys => other_keys }                                    }
+      let(:options)          { { keys: keys }                                             }
+      let(:other_options)    { { keys: other_keys }                                       }
 
       let(:other_keys) do
         Relation::Keys.coerce([ [ [ :name, String ], [ :age, Integer ] ] ])

--- a/spec/unit/axiom/relation/header/extend_spec.rb
+++ b/spec/unit/axiom/relation/header/extend_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe Relation::Header, '#extend' do
   subject { object.extend(attributes) }
 
-  let(:object) { described_class.coerce([ [ :id, Integer ] ], :keys => keys) }
-  let(:keys)   { Relation::Keys.new([ described_class.new ])                 }
+  let(:object) { described_class.coerce([ [ :id, Integer ] ], keys: keys) }
+  let(:keys)   { Relation::Keys.new([ described_class.new ])              }
 
   context 'with attribute objects' do
     let(:attributes) { [ attribute ]                }

--- a/spec/unit/axiom/relation/header/hash_spec.rb
+++ b/spec/unit/axiom/relation/header/hash_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 describe Relation::Header, '#hash' do
   subject { object.hash }
 
-  let(:object)    { described_class.new([ attribute ], :keys => keys) }
-  let(:attribute) { Attribute::Integer.new(:id)                       }
-  let(:keys)      { Relation::Keys.new                                }
+  let(:object)    { described_class.new([ attribute ], keys: keys) }
+  let(:attribute) { Attribute::Integer.new(:id)                    }
+  let(:keys)      { Relation::Keys.new                             }
 
   it_should_behave_like 'a hash method'
 

--- a/spec/unit/axiom/relation/header/intersect_spec.rb
+++ b/spec/unit/axiom/relation/header/intersect_spec.rb
@@ -45,7 +45,7 @@ require 'spec_helper'
 
     context 'when the keys are equivalent' do
       let(:other_attributes) { [ [ :id, Integer ], [ :name, String ], [ :age, Integer ] ] }
-      let(:options)          { { :keys => keys }                                          }
+      let(:options)          { { keys: keys }                                             }
 
       it { should be_instance_of(described_class) }
 
@@ -56,8 +56,8 @@ require 'spec_helper'
 
     context 'when the keys intersect' do
       let(:other_attributes) { [ [ :id, Integer ], [ :name, String ], [ :age, Integer ] ] }
-      let(:options)          { { :keys => keys }                                          }
-      let(:other_options)    { { :keys => other_keys }                                    }
+      let(:options)          { { keys: keys }                                             }
+      let(:other_options)    { { keys: other_keys }                                       }
 
       let(:other_keys) do
         Relation::Keys.coerce([
@@ -75,8 +75,8 @@ require 'spec_helper'
 
     context 'when the keys do not intersect' do
       let(:other_attributes) { [ [ :id, Integer ], [ :name, String ], [ :age, Integer ] ] }
-      let(:options)          { { :keys => keys }                                          }
-      let(:other_options)    { { :keys => other_keys }                                    }
+      let(:options)          { { keys: keys }                                             }
+      let(:other_options)    { { keys: other_keys }                                       }
 
       let(:other_keys) do
         Relation::Keys.coerce([ [ [ :name, String ], [ :age, Integer ] ] ])

--- a/spec/unit/axiom/relation/header/keys_spec.rb
+++ b/spec/unit/axiom/relation/header/keys_spec.rb
@@ -9,8 +9,8 @@ describe Relation::Header, '#keys' do
   let(:keys_class) { Relation::Keys                          }
 
   context 'with explicit keys' do
-    let(:object) { described_class.coerce(attributes, :keys => keys) }
-    let(:keys)   { [ [ :id ] ]                                       }
+    let(:object) { described_class.coerce(attributes, keys: keys) }
+    let(:keys)   { [ [ :id ] ]                                    }
 
     it { should be_instance_of(keys_class) }
 

--- a/spec/unit/axiom/relation/header/project_spec.rb
+++ b/spec/unit/axiom/relation/header/project_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Relation::Header, '#project' do
   subject { object.project(attributes) }
 
-  let(:object) { described_class.coerce([ [ :id, Integer ], [ :name, String ] ], :keys => keys)          }
+  let(:object) { described_class.coerce([ [ :id, Integer ], [ :name, String ] ], keys: keys)             }
   let(:keys)   { Relation::Keys.new([ described_class.coerce([ [ :id, Integer ], [ :name, String ] ]) ]) }
 
   context 'with attribute objects' do

--- a/spec/unit/axiom/relation/header/rename_spec.rb
+++ b/spec/unit/axiom/relation/header/rename_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 describe Relation::Header, '#rename' do
   subject { object.rename(aliases) }
 
-  let(:object)  { described_class.coerce([ [ :id, Integer ], [ :name, String ] ], :keys => keys) }
-  let(:aliases) { Algebra::Rename::Aliases.coerce(object, :id => :other_id)                      }
-  let(:keys)    { Relation::Keys.new([ described_class.coerce([ [ :id, Integer ] ]) ])           }
+  let(:object)  { described_class.coerce([ [ :id, Integer ], [ :name, String ] ], keys: keys) }
+  let(:aliases) { Algebra::Rename::Aliases.coerce(object, id: :other_id)                      }
+  let(:keys)    { Relation::Keys.new([ described_class.coerce([ [ :id, Integer ] ]) ])        }
 
   it { should be_instance_of(described_class) }
 

--- a/spec/unit/axiom/relation/header/union_spec.rb
+++ b/spec/unit/axiom/relation/header/union_spec.rb
@@ -45,7 +45,7 @@ require 'spec_helper'
 
     context 'when the keys are equivalent' do
       let(:other_attributes) { [ [ :id, Integer ], [ :name, String ], [ :age, Integer ] ] }
-      let(:options)          { { :keys => keys }                                          }
+      let(:options)          { { keys: keys }                                             }
 
       it { should be_instance_of(described_class) }
 
@@ -56,8 +56,8 @@ require 'spec_helper'
 
     context 'when the keys intersect' do
       let(:other_attributes) { [ [ :id, Integer ], [ :name, String ], [ :age, Integer ] ] }
-      let(:options)          { { :keys => keys }                                          }
-      let(:other_options)    { { :keys => other_keys }                                    }
+      let(:options)          { { keys: keys }                                             }
+      let(:other_options)    { { keys: other_keys }                                       }
 
       let(:other_keys) do
         Relation::Keys.coerce([
@@ -75,8 +75,8 @@ require 'spec_helper'
 
     context 'when the keys do not intersect' do
       let(:other_attributes) { [ [ :id, Integer ], [ :name, String ], [ :age, Integer ] ] }
-      let(:options)          { { :keys => keys }                                          }
-      let(:other_options)    { { :keys => other_keys }                                    }
+      let(:options)          { { keys: keys }                                             }
+      let(:other_options)    { { keys: other_keys }                                       }
 
       let(:other_keys) do
         Relation::Keys.coerce([ [ [ :name, String ], [ :age, Integer ] ] ])

--- a/spec/unit/axiom/relation/keys/rename_spec.rb
+++ b/spec/unit/axiom/relation/keys/rename_spec.rb
@@ -5,10 +5,10 @@ require 'spec_helper'
 describe Relation::Keys, '#rename' do
   subject { object.rename(aliases) }
 
-  let(:object)  { described_class.coerce([ header1, header2 ])               }
-  let(:header1) { [ [ :id, Integer ] ]                                       }
-  let(:header2) { [ [ :name, String ] ]                                      }
-  let(:aliases) { Algebra::Rename::Aliases.coerce(header1, :id => :other_id) }
+  let(:object)  { described_class.coerce([ header1, header2 ])            }
+  let(:header1) { [ [ :id, Integer ] ]                                    }
+  let(:header2) { [ [ :name, String ] ]                                   }
+  let(:aliases) { Algebra::Rename::Aliases.coerce(header1, id: :other_id) }
 
   it { should be_instance_of(described_class) }
 

--- a/spec/unit/axiom/relation/operation/order/direction/rename_spec.rb
+++ b/spec/unit/axiom/relation/operation/order/direction/rename_spec.rb
@@ -11,7 +11,7 @@ describe Relation::Operation::Order::Direction, '#rename' do
   let(:object)          { described_class.new(attribute)                   }
 
   context 'with aliases matching the attribute' do
-    let(:aliases) { Algebra::Rename::Aliases.coerce(header, :id => :other_id) }
+    let(:aliases) { Algebra::Rename::Aliases.coerce(header, id: :other_id) }
 
     it { should be_instance_of(described_class) }
 
@@ -19,9 +19,9 @@ describe Relation::Operation::Order::Direction, '#rename' do
   end
 
   context 'with aliases not matching the attribute' do
-    let(:other_attribute) { Attribute::String.new(:name)                                        }
-    let(:other_header)    { Relation::Header.new([ other_attribute ])                           }
-    let(:aliases)         { Algebra::Rename::Aliases.coerce(other_header, :name => :other_name) }
+    let(:other_attribute) { Attribute::String.new(:name)                                     }
+    let(:other_header)    { Relation::Header.new([ other_attribute ])                        }
+    let(:aliases)         { Algebra::Rename::Aliases.coerce(other_header, name: :other_name) }
 
     it { should equal(object) }
   end

--- a/spec/unit/axiom/relation/operation/order/direction/reverse_spec.rb
+++ b/spec/unit/axiom/relation/operation/order/direction/reverse_spec.rb
@@ -7,12 +7,12 @@ describe Relation::Operation::Order::Direction, '#reverse' do
 
   let(:described_class) { Class.new(Relation::Operation::Order::Direction) }
   let(:attribute)       { Attribute::Integer.new(:id)                      }
-  let(:reverse_class)   { mock('Reverse Class', :new => reverse)           }
+  let(:reverse_class)   { mock('Reverse Class', new: reverse)              }
   let(:reverse)         { mock('Reverse Instance')                         }
   let(:object)          { described_class.new(attribute)                   }
 
   before do
-    described_class.stub(:reverse => reverse_class)
+    described_class.stub(reverse: reverse_class)
   end
 
   it 'calls .reverse on the class' do

--- a/spec/unit/axiom/relation/operation/order/direction_set/rename_spec.rb
+++ b/spec/unit/axiom/relation/operation/order/direction_set/rename_spec.rb
@@ -5,10 +5,10 @@ require 'spec_helper'
 describe Relation::Operation::Order::DirectionSet, '#rename' do
   subject { object.rename(aliases) }
 
-  let(:attribute) { Attribute::Integer.new(:id)                               }
-  let(:header)    { Relation::Header.new([ attribute ])                       }
-  let(:aliases)   { Algebra::Rename::Aliases.coerce(header, :id => :other_id) }
-  let(:object)    { described_class.coerce([ attribute ])                     }
+  let(:attribute) { Attribute::Integer.new(:id)                            }
+  let(:header)    { Relation::Header.new([ attribute ])                    }
+  let(:aliases)   { Algebra::Rename::Aliases.coerce(header, id: :other_id) }
+  let(:object)    { described_class.coerce([ attribute ])                  }
 
   it { should_not equal(object) }
 

--- a/spec/unit/axiom/tuple/class_methods/coerce_spec.rb
+++ b/spec/unit/axiom/tuple/class_methods/coerce_spec.rb
@@ -24,7 +24,7 @@ describe Tuple, '.coerce' do
   end
 
   context 'when the argument is not a Tuple and does not respond to #to_ary' do
-    let(:argument) { { :id => 1 } }
+    let(:argument) { { id: 1 } }
 
     specify { expect { subject }.to raise_error(NoMethodError) }
   end

--- a/spec/unit/axiom/visitable/accept_spec.rb
+++ b/spec/unit/axiom/visitable/accept_spec.rb
@@ -6,7 +6,7 @@ describe Visitable, '#accept' do
   subject { object.accept(visitor) }
 
   let(:described_class) { Class.new { include Visitable } }
-  let(:visitor)         { mock('Visitor', :visit => nil)  }
+  let(:visitor)         { mock('Visitor', visit: nil)     }
   let(:object)          { described_class.new             }
 
   it_should_behave_like 'a command method'


### PR DESCRIPTION
This branch changes the library and specs to use the 1.9 Hash format.

On one hand, I'm not always a fan of this syntax (like when the key and value are `Symbol` objects), on the other hand it does make it absolutely clear the code is 1.9 only, so there's no mistaking our intentions.
