### PR TITLE
load axiom before ice_nine_config gets loaded

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require 'axiom'
 require 'devtools/spec_helper'
 
 if ENV['COVERAGE'] == 'true'
@@ -20,6 +19,7 @@ if ENV['COVERAGE'] == 'true'
   end
 end
 
+require 'axiom'
 include Axiom
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require 'axiom'
 require 'devtools/spec_helper'
 
 if ENV['COVERAGE'] == 'true'
@@ -18,8 +19,6 @@ if ENV['COVERAGE'] == 'true'
     minimum_coverage 100
   end
 end
-
-require 'axiom'
 
 include Axiom
 

--- a/spec/support/ice_nine_config.rb
+++ b/spec/support/ice_nine_config.rb
@@ -1,8 +1,10 @@
 # encoding: utf-8
 
-module IceNine
-  class Freezer
-    class RSpec < NoFreeze
+if defined?(IceNine)
+  module IceNine
+    class Freezer
+      class RSpec < NoFreeze
+      end
     end
   end
 end


### PR DESCRIPTION
``` shell
$ bundle install
$ bundle exec rspec spec
spec/support/ice_nine_config.rb:5:in `<class:Freezer>': uninitialized constant IceNine::Freezer::NoFreeze (NameError)
```

Need to load axiom before ice_nine_config gets loaded to solve the above exception.
