### PR TITLE
[WIP] Upgrade equalizer and use adamantium from master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'axiom-types', '~> 0.0.5', git: 'https://github.com/dkubb/axiom-types.git'
+gem 'axiom-types', '~> 0.0.5', git: 'https://github.com/dkubb/axiom-types.git', branch: 'master'
+gem 'adamantium', '~> 0.1', git: 'https://github.com/dkubb/adamantium.git', branch: 'master'
 
 platform :rbx do
   gem 'rubysl-bigdecimal', '~> 2.0.2'

--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -11,17 +11,17 @@ group :development do
 end
 
 group :yard do
-  gem 'kramdown', '~> 1.2.0'
+  gem 'kramdown', '~> 1.3.0'
 end
 
 group :guard do
   gem 'guard',         '~> 2.2.4'
   gem 'guard-bundler', '~> 2.0.0'
-  gem 'guard-rspec',   '~> 4.0.4'
+  gem 'guard-rspec',   '~> 4.2.0'
   gem 'guard-rubocop', '~> 1.0.0'
 
   # file system change event handling
-  gem 'listen',     '~> 2.2.0'
+  gem 'listen',     '~> 2.4.0'
   gem 'rb-fchange', '~> 0.0.6', require: false
   gem 'rb-fsevent', '~> 0.9.3', require: false
   gem 'rb-inotify', '~> 0.9.0', require: false
@@ -37,13 +37,15 @@ group :metrics do
   gem 'flay',      '~> 2.4.0'
   gem 'flog',      '~> 4.2.0'
   gem 'reek',      '~> 1.3.2'
-  gem 'rubocop',   '~> 0.15.0'
+  gem 'rubocop',   '~> 0.16.0'
   gem 'simplecov', '~> 0.8.2'
-  gem 'yardstick', '~> 0.9.7', git: 'https://github.com/dkubb/yardstick.git'
+  gem 'yardstick', '~> 0.9.9'
+
+  platforms :mri do
+    gem 'mutant', '~> 0.3.4'
+  end
 
   platforms :ruby_19, :ruby_20 do
-    gem 'mutant',          '~> 0.3.0.rc3', git: 'https://github.com/mbj/mutant.git'
-    gem 'unparser',        '~> 0.1.5',     git: 'https://github.com/mbj/unparser.git'
     gem 'yard-spellcheck', '~> 0.1.5'
   end
 

--- a/axiom.gemspec
+++ b/axiom.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = %w[LICENSE README.md CONTRIBUTING.md TODO]
 
   gem.add_runtime_dependency('abstract_type',       '~> 0.0.7')
-  gem.add_runtime_dependency('adamantium',          '~> 0.1.0')
+  gem.add_runtime_dependency('adamantium',          '~> 0.1')
   gem.add_runtime_dependency('axiom-types',         '~> 0.0.5')
   gem.add_runtime_dependency('descendants_tracker', '~> 0.0.3')
-  gem.add_runtime_dependency('equalizer',           '~> 0.0.8')
+  gem.add_runtime_dependency('equalizer',           '~> 0.0.9')
 
   gem.add_development_dependency('bundler', '~> 1.3', '>= 1.3.5')
 end


### PR DESCRIPTION
This branch upgrades equalizer to 0.0.9 and uses adamatium from master which no longer has the issue described in #51 

There's 27 failing tests related to changed implementation of `#hash` method in equalizer (IIRC). Personally I'd vote for removing those tests altogether since it is a feature coming from Equalizer gem and it is tested there. I don't see any reason why this should be tested here (again, those tests check implementation details, very little value). Alternatively we could have tests for `#eql?` instead of `#hash` which would test behavior and not implementation. Yes, I've become a huge BDD fan lately ;)

Another problem is with adamantium from master, even though #51 is no longer a problem with edge adamantium there's a lot of failures ending up with an error like that:

```
 144) Axiom::Function::Predicate::LessThan#inverse right
   Failure/Error: subject { object.inverse }
   ArgumentError:
     wrong number of arguments (2 for 1)
   # /Users/solnic/.gem/ruby/1.9.3/gems/memoizable-0.4.0/lib/memoizable/instance_methods.rb:32:in `memoize'
   # ./lib/axiom/function/binary.rb:87:in `inverse'
  ...
```

I guess some public interface in adamantium changed and axiom should be updated. I can do that but I need some guidance.
