### PR TITLE
Mutant config

### DIFF
--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -1,9 +1,10 @@
 # encoding: utf-8
 
 group :development do
-  gem 'rake',  '~> 10.1.0'
-  gem 'rspec', '~> 2.14.1'
-  gem 'yard',  '~> 0.8.7'
+  gem 'rake',       '~> 10.1.0'
+  gem 'rspec',      '~> 2.14.1'
+  gem 'rspec-core', '~> 2.14.8'
+  gem 'yard',       '~> 0.8.7'
 
   platform :rbx do
     gem 'rubysl-singleton', '~> 2.0.0'
@@ -11,17 +12,17 @@ group :development do
 end
 
 group :yard do
-  gem 'kramdown', '~> 1.3.0'
+  gem 'kramdown', '~> 1.3.2'
 end
 
 group :guard do
-  gem 'guard',         '~> 2.3.0'
+  gem 'guard',         '~> 2.4.0'
   gem 'guard-bundler', '~> 2.0.0'
-  gem 'guard-rspec',   '~> 4.2.0'
-  gem 'guard-rubocop', '~> 1.0.0'
+  gem 'guard-rspec',   '~> 4.2.6'
+  gem 'guard-rubocop', '~> 1.0.2'
 
   # file system change event handling
-  gem 'listen',     '~> 2.4.0'
+  gem 'listen',     '~> 2.5.0'
   gem 'rb-fchange', '~> 0.0.6', require: false
   gem 'rb-fsevent', '~> 0.9.3', require: false
   gem 'rb-inotify', '~> 0.9.0', require: false
@@ -37,12 +38,13 @@ group :metrics do
   gem 'flay',      '~> 2.4.0'
   gem 'flog',      '~> 4.2.0'
   gem 'reek',      '~> 1.3.2'
-  gem 'rubocop',   '~> 0.16.0'
+  gem 'rubocop',   '~> 0.18.1'
   gem 'simplecov', '~> 0.8.2'
   gem 'yardstick', '~> 0.9.9'
 
   platforms :mri do
-    gem 'mutant', '~> 0.3.4'
+    gem 'mutant',       '~> 0.5.3'
+    gem 'mutant-rspec', '~> 0.5.3'
   end
 
   platforms :ruby_19, :ruby_20 do

--- a/Rakefile
+++ b/Rakefile
@@ -3,3 +3,55 @@
 require 'devtools'
 
 Devtools.init_rake_tasks
+
+# Remove metrics:mutant from devtools
+task('metrics:mutant').clear
+
+namespace :metrics do
+  allowed_versions = %w(mri-1.9.3 mri-2.0.0 mri-2.1.0 rbx-1.9.3)
+
+  enabled = begin
+    require 'mutant'
+  rescue LoadError, NotImplementedError
+    false
+  end
+
+  config    = Devtools.project.mutant
+  enabled &&= config.enabled? && allowed_versions.include?(Devtools.rvm)
+
+  zombify = %w(
+    adamantium equalizer ice_nine infecto anima concord abstract_type
+    descendants_tracker parser rspec unparser mutant
+  ).include?(config.name)
+
+  if enabled && !ENV['DEVTOOLS_SELF']
+    desc 'Measure mutation coverage'
+    task mutant: :coverage do
+      namespace =
+        if zombify
+          Mutant::Zombifier.zombify
+          Zombie::Mutant
+        else
+          Mutant
+        end
+
+      namespaces = Array(config.namespace).map { |n| "::#{n}*" }
+      arguments  = %W[
+        --include lib
+        --require #{config.name}
+        --ignore-subject Axiom::Types*
+        --use #{config.strategy}
+      ].concat(namespaces)
+
+      status = namespace::CLI.run(arguments)
+      if status.nonzero?
+        Devtools.notify_metric_violation 'Mutant task is not successful'
+      end
+    end
+  else
+    desc 'Measure mutation coverage'
+    task mutant: :coverage do
+      $stderr.puts 'Mutant is disabled'
+    end
+  end
+end


### PR DESCRIPTION
Adds a mutant specific rake task that excludes `Axiom::Types*` namespace from the mutated subjects. Once mutant will finally support more fine grained configuration files we can get a rid from this.
